### PR TITLE
feat: add 9 MCP tool classes (54 tools)

### DIFF
--- a/modules/addons/nt_mcp/src/Tools/BillingTools.php
+++ b/modules/addons/nt_mcp/src/Tools/BillingTools.php
@@ -1,0 +1,61 @@
+<?php
+// src/Tools/BillingTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class BillingTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_invoices', description: 'Lista faturas com filtros')]
+    public function listInvoices(int $clientid = 0, string $status = '', int $limitnum = 25): string
+    {
+        $params = ['limitnum' => $limitnum];
+        if ($clientid > 0) $params['userid'] = $clientid;
+        if ($status !== '') $params['status'] = $status;
+        return json_encode($this->api->call('GetInvoices', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_invoice', description: 'Obtém detalhes de uma fatura')]
+    public function getInvoice(int $invoiceid): string
+    {
+        return json_encode($this->api->call('GetInvoice', ['invoiceid' => $invoiceid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_create_invoice', description: 'Cria uma nova fatura manualmente')]
+    public function createInvoice(int $userid, string $date, array $itemdescription, array $itemamount): string
+    {
+        return json_encode($this->api->call('CreateInvoice', [
+            'userid' => $userid,
+            'date'   => $date,
+            'itemdescription' => $itemdescription,
+            'itemamount'      => $itemamount,
+        ]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_add_payment', description: 'Registra pagamento em uma fatura')]
+    public function addPayment(int $invoiceid, string $transid, float $amount, string $gateway): string
+    {
+        return json_encode($this->api->call('AddInvoicePayment', compact('invoiceid', 'transid', 'amount', 'gateway')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_invoice', description: 'Atualiza status ou dados de uma fatura')]
+    public function updateInvoice(int $invoiceid, string $status = '', string $duedate = ''): string
+    {
+        $params = ['invoiceid' => $invoiceid];
+        if ($status !== '') $params['status'] = $status;
+        if ($duedate !== '') $params['duedate'] = $duedate;
+        return json_encode($this->api->call('UpdateInvoice', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_transactions', description: 'Lista transações financeiras')]
+    public function getTransactions(int $clientid = 0, string $transid = ''): string
+    {
+        $params = [];
+        if ($clientid > 0) $params['clientid'] = $clientid;
+        if ($transid !== '') $params['transid'] = $transid;
+        return json_encode($this->api->call('GetTransactions', $params), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/ClientTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ClientTools.php
@@ -1,0 +1,92 @@
+<?php
+// src/Tools/ClientTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class ClientTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(
+        name: 'whmcs_list_clients',
+        description: 'Lista clientes do WHMCS com filtros opcionais'
+    )]
+    public function listClients(
+        string $search = '',
+        int $limitstart = 0,
+        int $limitnum = 25
+    ): string {
+        $params = ['limitstart' => $limitstart, 'limitnum' => $limitnum];
+        if ($search !== '') $params['search'] = $search;
+
+        return json_encode($this->api->call('GetClients', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(
+        name: 'whmcs_get_client',
+        description: 'Obtém detalhes completos de um cliente por ID'
+    )]
+    public function getClient(int $clientid): string
+    {
+        return json_encode(
+            $this->api->call('GetClientsDetails', ['clientid' => $clientid, 'stats' => true]),
+            JSON_PRETTY_PRINT
+        );
+    }
+
+    #[McpTool(
+        name: 'whmcs_create_client',
+        description: 'Cria um novo cliente no WHMCS'
+    )]
+    public function createClient(
+        string $firstname,
+        string $lastname,
+        string $email,
+        string $password2,
+        string $address1 = '',
+        string $city = '',
+        string $state = '',
+        string $postcode = '',
+        string $country = 'BR',
+        string $phonenumber = ''
+    ): string {
+        return json_encode($this->api->call('AddClient', compact(
+            'firstname', 'lastname', 'email', 'password2',
+            'address1', 'city', 'state', 'postcode', 'country', 'phonenumber'
+        )), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_client', description: 'Atualiza dados de um cliente existente')]
+    public function updateClient(int $clientid, array $fields = []): string
+    {
+        return json_encode($this->api->call('UpdateClient', array_merge(['clientid' => $clientid], $fields)), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_close_client', description: 'Fecha/cancela a conta de um cliente')]
+    public function closeClient(int $clientid): string
+    {
+        return json_encode($this->api->call('CloseClient', ['clientid' => $clientid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_client_products', description: 'Lista produtos/serviços ativos de um cliente')]
+    public function getClientProducts(int $clientid): string
+    {
+        return json_encode($this->api->call('GetClientsProducts', ['clientid' => $clientid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_client_domains', description: 'Lista domínios de um cliente')]
+    public function getClientDomains(int $clientid): string
+    {
+        return json_encode($this->api->call('GetClientsDomains', ['clientid' => $clientid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_client_invoices', description: 'Lista faturas de um cliente')]
+    public function getClientInvoices(int $clientid, string $status = ''): string
+    {
+        $params = ['userid' => $clientid];
+        if ($status !== '') $params['status'] = $status;
+        return json_encode($this->api->call('GetInvoices', $params), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/CrmTools.php
+++ b/modules/addons/nt_mcp/src/Tools/CrmTools.php
@@ -1,0 +1,98 @@
+<?php
+// src/Tools/CrmTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\CapsuleClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class CrmTools
+{
+    // Confirmar nomes das tabelas no banco de dados do WHMCS
+    private const TABLE_CONTACTS = 'mod_mgcrm_contacts';
+    private const TABLE_FOLLOWUPS = 'mod_mgcrm_followups';
+    private const TABLE_NOTES = 'mod_mgcrm_notes';
+
+    public function __construct(private readonly CapsuleClient $capsule) {}
+
+    #[McpTool(name: 'whmcs_crm_list_contacts', description: 'Lista contatos/leads do CRM ModulesGarden')]
+    public function listContacts(string $type = '', int $limit = 25, int $offset = 0): string
+    {
+        $where = $type !== '' ? ['type' => $type] : [];
+        return json_encode($this->capsule->select(self::TABLE_CONTACTS, $where, ['*'], $limit, $offset), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_get_contact', description: 'Obtém detalhes de um contato CRM')]
+    public function getContact(int $id): string
+    {
+        $contacts = $this->capsule->select(self::TABLE_CONTACTS, ['id' => $id], ['*'], 1);
+        return json_encode($contacts[0] ?? null, JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_create_lead', description: 'Cria um novo lead no CRM ModulesGarden')]
+    public function createLead(
+        string $name,
+        string $email,
+        string $phone = '',
+        string $company = '',
+        string $notes = ''
+    ): string {
+        $id = $this->capsule->insert(self::TABLE_CONTACTS, [
+            'type'    => 'lead',
+            'name'    => $name,
+            'email'   => $email,
+            'phone'   => $phone,
+            'company' => $company,
+            'notes'   => $notes,
+            'created' => date('Y-m-d H:i:s'),
+        ]);
+        return json_encode(['result' => 'success', 'id' => $id], JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_update_contact', description: 'Atualiza dados de um contato CRM')]
+    public function updateContact(int $id, array $fields): string
+    {
+        $count = $this->capsule->update(self::TABLE_CONTACTS, ['id' => $id], $fields);
+        return json_encode(['result' => 'success', 'rows_affected' => $count], JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_add_followup', description: 'Adiciona um follow-up a um contato CRM')]
+    public function addFollowup(int $contactId, string $note, string $duedate): string
+    {
+        $id = $this->capsule->insert(self::TABLE_FOLLOWUPS, [
+            'contact_id' => $contactId,
+            'note'       => $note,
+            'duedate'    => $duedate,
+            'created'    => date('Y-m-d H:i:s'),
+        ]);
+        return json_encode(['result' => 'success', 'id' => $id], JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_add_note', description: 'Adiciona uma nota a um contato CRM')]
+    public function addNote(int $contactId, string $note): string
+    {
+        $id = $this->capsule->insert(self::TABLE_NOTES, [
+            'contact_id' => $contactId,
+            'note'       => $note,
+            'created'    => date('Y-m-d H:i:s'),
+        ]);
+        return json_encode(['result' => 'success', 'id' => $id], JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_list_followups', description: 'Lista follow-ups de um contato CRM')]
+    public function listFollowups(int $contactId, int $limit = 25): string
+    {
+        return json_encode($this->capsule->select(self::TABLE_FOLLOWUPS, ['contact_id' => $contactId], ['*'], $limit), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_crm_get_kanban', description: 'Retorna visão Kanban dos contatos agrupados por estágio')]
+    public function getKanban(): string
+    {
+        $contacts = $this->capsule->select(self::TABLE_CONTACTS, [], ['*'], 500);
+        $kanban = [];
+        foreach ($contacts as $contact) {
+            $stage = $contact['status'] ?? $contact['stage'] ?? 'Unknown';
+            $kanban[$stage][] = $contact;
+        }
+        return json_encode($kanban, JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/DomainTools.php
+++ b/modules/addons/nt_mcp/src/Tools/DomainTools.php
@@ -1,0 +1,38 @@
+<?php
+// src/Tools/DomainTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class DomainTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_domains', description: 'Lista domínios registrados no WHMCS')]
+    public function listDomains(int $clientid = 0, string $status = ''): string
+    {
+        $params = [];
+        if ($clientid > 0) $params['clientid'] = $clientid;
+        if ($status !== '') $params['status'] = $status;
+        return json_encode($this->api->call('GetClientsDomains', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_register_domain', description: 'Registra um novo domínio')]
+    public function registerDomain(int $clientid, string $domain, int $regperiod = 1, string $nameserver1 = '', string $nameserver2 = ''): string
+    {
+        return json_encode($this->api->call('DomainRegister', compact('clientid', 'domain', 'regperiod', 'nameserver1', 'nameserver2')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_renew_domain', description: 'Renova o registro de um domínio')]
+    public function renewDomain(int $domainid, int $regperiod = 1): string
+    {
+        return json_encode($this->api->call('DomainRenew', compact('domainid', 'regperiod')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_nameservers', description: 'Atualiza nameservers de um domínio')]
+    public function updateNameservers(int $domainid, string $ns1, string $ns2, string $ns3 = '', string $ns4 = ''): string
+    {
+        return json_encode($this->api->call('DomainUpdateNameservers', array_filter(compact('domainid', 'ns1', 'ns2', 'ns3', 'ns4'))), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/OrderTools.php
+++ b/modules/addons/nt_mcp/src/Tools/OrderTools.php
@@ -1,0 +1,50 @@
+<?php
+// src/Tools/OrderTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class OrderTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_orders', description: 'Lista pedidos com filtros opcionais')]
+    public function listOrders(string $status = '', int $clientid = 0, int $limitnum = 25): string
+    {
+        $params = ['limitnum' => $limitnum];
+        if ($status !== '') $params['status'] = $status;
+        if ($clientid > 0) $params['userid'] = $clientid;
+        return json_encode($this->api->call('GetOrders', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_order', description: 'Obtém detalhes de um pedido específico')]
+    public function getOrder(int $orderid): string
+    {
+        return json_encode($this->api->call('GetOrders', ['id' => $orderid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_accept_order', description: 'Aceita um pedido pendente e provisiona os serviços')]
+    public function acceptOrder(int $orderid, bool $sendEmail = true): string
+    {
+        return json_encode($this->api->call('AcceptOrder', [
+            'orderid' => $orderid,
+            'sendemail' => $sendEmail ? 'true' : 'false',
+        ]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_cancel_order', description: 'Cancela um pedido')]
+    public function cancelOrder(int $orderid, bool $sendEmail = false): string
+    {
+        return json_encode($this->api->call('CancelOrder', [
+            'orderid' => $orderid,
+            'sendemail' => $sendEmail ? 'true' : 'false',
+        ]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_delete_order', description: 'Deleta permanentemente um pedido cancelado')]
+    public function deleteOrder(int $orderid): string
+    {
+        return json_encode($this->api->call('DeleteOrder', ['orderid' => $orderid]), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/ProjectManagerTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ProjectManagerTools.php
@@ -1,0 +1,117 @@
+<?php
+// src/Tools/ProjectManagerTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class ProjectManagerTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_projects', description: 'Lista projetos com filtros opcionais')]
+    public function listProjects(
+        int $userid = 0,
+        string $status = '',
+        bool $completed = false,
+        int $limitnum = 25,
+        int $limitstart = 0
+    ): string {
+        $params = ['limitnum' => $limitnum, 'limitstart' => $limitstart];
+        if ($userid > 0) $params['userid'] = $userid;
+        if ($status !== '') $params['status'] = $status;
+        if ($completed) $params['completed'] = true;
+        return json_encode($this->api->call('GetProjects', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_project', description: 'Obtém detalhes completos de um projeto incluindo tarefas')]
+    public function getProject(int $projectid): string
+    {
+        return json_encode($this->api->call('GetProject', ['projectid' => $projectid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_create_project', description: 'Cria um novo projeto no WHMCS Project Manager')]
+    public function createProject(
+        string $title,
+        int $adminid,
+        int $userid = 0,
+        string $status = '',
+        string $duedate = '',
+        string $notes = ''
+    ): string {
+        $params = ['title' => $title, 'adminid' => $adminid];
+        if ($userid > 0) $params['userid'] = $userid;
+        if ($status !== '') $params['status'] = $status;
+        if ($duedate !== '') $params['duedate'] = $duedate;
+        if ($notes !== '') $params['notes'] = $notes;
+        return json_encode($this->api->call('CreateProject', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_project', description: 'Atualiza um projeto existente')]
+    public function updateProject(
+        int $projectid,
+        string $title = '',
+        string $status = '',
+        string $duedate = '',
+        bool $completed = false
+    ): string {
+        $params = ['projectid' => $projectid];
+        if ($title !== '') $params['title'] = $title;
+        if ($status !== '') $params['status'] = $status;
+        if ($duedate !== '') $params['duedate'] = $duedate;
+        if ($completed) $params['completed'] = true;
+        return json_encode($this->api->call('UpdateProject', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_add_project_task', description: 'Adiciona uma tarefa a um projeto')]
+    public function addProjectTask(
+        int $projectid,
+        string $task,
+        string $duedate,
+        int $adminid,
+        bool $completed = false
+    ): string {
+        return json_encode($this->api->call('AddProjectTask', compact(
+            'projectid', 'task', 'duedate', 'adminid', 'completed'
+        )), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_project_task', description: 'Atualiza uma tarefa de projeto')]
+    public function updateProjectTask(
+        int $projectid,
+        int $taskid,
+        string $task = '',
+        string $duedate = '',
+        bool $completed = false
+    ): string {
+        $params = ['projectid' => $projectid, 'taskid' => $taskid];
+        if ($task !== '') $params['task'] = $task;
+        if ($duedate !== '') $params['duedate'] = $duedate;
+        if ($completed) $params['completed'] = true;
+        return json_encode($this->api->call('UpdateProjectTask', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_delete_project_task', description: 'Remove uma tarefa de um projeto')]
+    public function deleteProjectTask(int $projectid, int $taskid): string
+    {
+        return json_encode($this->api->call('DeleteProjectTask', compact('projectid', 'taskid')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_start_task_timer', description: 'Inicia cronômetro de uma tarefa (time tracking)')]
+    public function startTaskTimer(int $projectid, int $taskid, int $adminid): string
+    {
+        return json_encode($this->api->call('StartTaskTimer', compact('projectid', 'taskid', 'adminid')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_end_task_timer', description: 'Para cronômetro de uma tarefa')]
+    public function endTaskTimer(int $projectid, int $taskid, int $adminid): string
+    {
+        return json_encode($this->api->call('EndTaskTimer', compact('projectid', 'taskid', 'adminid')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_add_project_message', description: 'Adiciona mensagem/comentário a um projeto')]
+    public function addProjectMessage(int $projectid, string $message, int $adminid): string
+    {
+        return json_encode($this->api->call('AddProjectMessage', compact('projectid', 'message', 'adminid')), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/ServiceTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ServiceTools.php
@@ -37,11 +37,19 @@ class ServiceTools
     }
 
     #[McpTool(name: 'whmcs_upgrade_service', description: 'Faz upgrade de plano de um serviço')]
-    public function upgradeService(int $serviceid, int $newproductid): string
-    {
+    public function upgradeService(
+        int $serviceid,
+        int $newproductid,
+        string $paymentmethod,
+        string $newproductbillingcycle = 'monthly',
+        string $type = 'product'
+    ): string {
         return json_encode($this->api->call('UpgradeProduct', [
             'serviceid' => $serviceid,
+            'type' => $type,
             'newproductid' => $newproductid,
+            'newproductbillingcycle' => $newproductbillingcycle,
+            'paymentmethod' => $paymentmethod,
         ]), JSON_PRETTY_PRINT);
     }
 }

--- a/modules/addons/nt_mcp/src/Tools/ServiceTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ServiceTools.php
@@ -1,0 +1,47 @@
+<?php
+// src/Tools/ServiceTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class ServiceTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_services', description: 'Lista serviços/produtos ativos de um cliente')]
+    public function listServices(int $clientid = 0, string $status = ''): string
+    {
+        $params = [];
+        if ($clientid > 0) $params['clientid'] = $clientid;
+        if ($status !== '') $params['status'] = $status;
+        return json_encode($this->api->call('GetClientsProducts', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_suspend_service', description: 'Suspende um serviço de hospedagem/servidor')]
+    public function suspendService(int $serviceid, string $reason = ''): string
+    {
+        return json_encode($this->api->call('ModuleSuspend', ['serviceid' => $serviceid, 'suspendreason' => $reason]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_unsuspend_service', description: 'Reativa um serviço suspenso')]
+    public function unsuspendService(int $serviceid): string
+    {
+        return json_encode($this->api->call('ModuleUnsuspend', ['serviceid' => $serviceid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_terminate_service', description: 'Termina/cancela definitivamente um serviço')]
+    public function terminateService(int $serviceid): string
+    {
+        return json_encode($this->api->call('ModuleTerminate', ['serviceid' => $serviceid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_upgrade_service', description: 'Faz upgrade de plano de um serviço')]
+    public function upgradeService(int $serviceid, int $newproductid): string
+    {
+        return json_encode($this->api->call('UpgradeProduct', [
+            'serviceid' => $serviceid,
+            'newproductid' => $newproductid,
+        ]), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/SystemTools.php
+++ b/modules/addons/nt_mcp/src/Tools/SystemTools.php
@@ -1,0 +1,29 @@
+<?php
+// src/Tools/SystemTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class SystemTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_get_stats', description: 'Retorna estatísticas gerais do WHMCS (receita, clientes, tickets)')]
+    public function getStats(): string
+    {
+        return json_encode($this->api->call('GetStats', []), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_send_email', description: 'Envia um email usando template do WHMCS')]
+    public function sendEmail(int $id, string $messagename, string $customtype = 'general'): string
+    {
+        return json_encode($this->api->call('SendEmail', compact('id', 'messagename', 'customtype')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_activity_log', description: 'Obtém log de atividades do sistema')]
+    public function getActivityLog(int $limitnum = 25, int $limitstart = 0): string
+    {
+        return json_encode($this->api->call('GetActivityLog', compact('limitnum', 'limitstart')), JSON_PRETTY_PRINT);
+    }
+}

--- a/modules/addons/nt_mcp/src/Tools/TicketTools.php
+++ b/modules/addons/nt_mcp/src/Tools/TicketTools.php
@@ -1,0 +1,47 @@
+<?php
+// src/Tools/TicketTools.php
+namespace NtMcp\Tools;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PhpMcp\Server\Attributes\McpTool;
+
+class TicketTools
+{
+    public function __construct(private readonly LocalApiClient $api) {}
+
+    #[McpTool(name: 'whmcs_list_tickets', description: 'Lista tickets de suporte')]
+    public function listTickets(int $clientid = 0, string $status = 'Open', int $limitnum = 25): string
+    {
+        $params = ['limitnum' => $limitnum, 'status' => $status];
+        if ($clientid > 0) $params['clientid'] = $clientid;
+        return json_encode($this->api->call('GetTickets', $params), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_get_ticket', description: 'Obtém detalhes e histórico de um ticket')]
+    public function getTicket(int $ticketid): string
+    {
+        return json_encode($this->api->call('GetTicket', ['ticketid' => $ticketid]), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_open_ticket', description: 'Abre um novo ticket de suporte')]
+    public function openTicket(int $clientid, int $deptid, string $subject, string $message, string $priority = 'Medium'): string
+    {
+        return json_encode($this->api->call('OpenTicket', compact('clientid', 'deptid', 'subject', 'message', 'priority')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_reply_ticket', description: 'Adiciona resposta a um ticket existente')]
+    public function replyTicket(int $ticketid, string $message, string $status = 'Customer-Reply'): string
+    {
+        return json_encode($this->api->call('AddTicketReply', compact('ticketid', 'message', 'status')), JSON_PRETTY_PRINT);
+    }
+
+    #[McpTool(name: 'whmcs_update_ticket', description: 'Atualiza status, prioridade ou departamento de um ticket')]
+    public function updateTicket(int $ticketid, string $status = '', string $priority = '', int $deptid = 0): string
+    {
+        $params = ['ticketid' => $ticketid];
+        if ($status !== '') $params['status'] = $status;
+        if ($priority !== '') $params['priority'] = $priority;
+        if ($deptid > 0) $params['deptid'] = $deptid;
+        return json_encode($this->api->call('UpdateTicket', $params), JSON_PRETTY_PRINT);
+    }
+}


### PR DESCRIPTION
## Summary

- Add all 9 MCP tool classes covering 54 WHMCS operations
- ClientTools (8), OrderTools (5), BillingTools (6), TicketTools (5), ServiceTools (5), DomainTools (4), SystemTools (3), ProjectManagerTools (10), CrmTools (8 via Capsule ORM)
- All tools use `#[McpTool]` PHP attributes for auto-discovery by php-mcp/server

## Test plan

- [ ] Run `phpunit --testdox` — all 6 existing tests pass
- [ ] Verify `grep -c '#\[McpTool\]' src/Tools/*.php` totals 54
- [ ] Deploy to WHMCS and verify `tools/list` returns all tools
- [ ] Test representative tool via curl (e.g. `whmcs_get_stats`)

🤖 Generated with [Claude Code](https://claude.ai/code)