### PR TITLE
security: fixes P0 — gate de escrita, clamp de impersonação, redação de PII e confiança de transporte

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ lftp -u desenvnt5442 -e "set ssl:verify-certificate no; mirror --exclude vendor/
 - CSRF: HMAC-SHA256 nonce em todos os forms admin
 - Command allowlist: 83 comandos em `LocalApiClient::ALLOWED_COMMANDS`
 - Table/column allowlist: 3 tabelas CRM em `CapsuleClient::ALLOWED_TABLES/COLUMNS`
-- Trusted proxy IP: `IpResolver::resolve()` — rightmost-untrusted from X-Forwarded-For behind configured proxies
+- Trusted proxy IP: `IpResolver::resolve()` — usa `\App::getClientIp()` do WHMCS quando disponível (coherence guard contra spoof em conexão direta); `isTrustedProxy()` mescla Trusted Proxies nativo (aba Security, chave `TrustedProxyIps`) ∪ `nt_mcp_trusted_proxies` (aditivo/opcional); fallback rightmost-untrusted XFF
 - Content-Length guard: Server.php rejeita >1MB
 - customfields: json_encode (sem serialize), max 50 fields, 8KB, scalar-only
 - Passwords stripped de responses (ClientTools, ServiceTools)
@@ -83,6 +83,8 @@ lftp -u desenvnt5442 -e "set ssl:verify-certificate no; mirror --exclude vendor/
 - Per-token admin binding: cada token registra qual admin o criou/aprovou
 - File access: 5 .htaccess (root, data/, src/, vendor/, tests/) — whitelist apenas mcp.php, oauth.php, nt_mcp.php
 - CapsuleClient query limit: MAX 500 rows por SELECT (hard-clamped)
+- Write-class gate (WO-2): `LocalApiClient` classifica cada comando (READ/WRITE/DESTRUCTIVE/FINANCIAL/COST/COMMS). WRITE on por padrão; DESTRUCTIVE/FINANCIAL/COST/COMMS bloqueados por padrão (opt-in `nt_mcp_enable_*`); master switch `nt_mcp_readonly` (fail-closed). Espelhado em `CapsuleClient::assertWritable()`. `AcceptQuote`=FINANCIAL (gera fatura). Impersonação clampada: `adminid`/`adminusername` forçados ao admin do token
+- Admin fail-closed (WO-7): sem `nt_mcp_admin_user` resolvível, `BearerAuth` e `Server::run()` negam (401) — nunca vinculam ao superadmin `admin`
 
 ## Gotchas
 
@@ -107,3 +109,5 @@ lftp -u desenvnt5442 -e "set ssl:verify-certificate no; mirror --exclude vendor/
 - **property_exists() guard** — colunas novas (`admin_user`, `approved_by`, `last_used_at`) podem não existir em DBs pré-migration; usar `property_exists($row, 'col')` antes de acessar
 - **Pending audit findings** — F-05, F-10, F-12 resolvidos. Resolvidos no refactor: F-07 (RateLimiter), F-11 (TokenHandler). Mitigados: F-06 (IpAllowlist), F-14 (SystemUrl — intencional)
 - **Semgrep PHP parser** — não suporta constructor promotion com `readonly` (PHP 8.2); RateLimiter gera PartialParsing warning, findings nesse arquivo podem ser incompletos
+- **Trusted proxy unificado (WO-TP)** — `IpResolver` reusa o IP resolvido pelo WHMCS (`\App::getClientIp()`) e mescla a lista nativa `TrustedProxyIps` (aba Security) ∪ `nt_mcp_trusted_proxies`. Consequências: (i) proxies da lista NATIVA também autorizam `X-Forwarded-Proto` e `NT_MCP_ALLOW_HTTP` no `TlsEnforcer` — liste só proxies próprios na aba Security; (ii) o caminho nativo honra o "Proxy IP Header" (ex.: CF-Connecting-IP), mas o fallback só lê `X-Forwarded-For`; (iii) se a chave nativa não for `TrustedProxyIps` na versão instalada, a unificação vira no-op — observável pelo error_log "X-Forwarded-For present but no trusted proxies configured". `nt_mcp_trusted_proxies` é agora opcional/aditivo
+- **Config obrigatória pré-deploy** — `nt_mcp_admin_user` DEVE estar setado antes do deploy (senão 401 fail-closed, ver WO-7); operador também configura `nt_mcp_allowed_ips`, `nt_mcp_cors_origins`, e (opcional) `nt_mcp_trusted_proxies` / Trusted Proxies nativo do WHMCS

--- a/modules/addons/nt_mcp/oauth.php
+++ b/modules/addons/nt_mcp/oauth.php
@@ -14,18 +14,31 @@
  *   POST /token                                → Token exchange
  */
 
+// 1. Autoload do Composer PRIMEIRO — garante que psr/log v3 e demais
+//    PSR packages do addon sejam registrados antes do WHMCS carregar
+//    suas versões v1, evitando fatal "declaration compatibility" errors.
+require_once __DIR__ . '/vendor/autoload.php';
+
+// 2. Inicializar WHMCS (3 niveis: addons/nt_mcp -> modules -> whmcs root)
 define('CLIENTAREA', true);
 require_once __DIR__ . '/../../../init.php';
-require_once __DIR__ . '/vendor/autoload.php';
 
 use NtMcp\Http\TlsEnforcer;
 use NtMcp\Http\SecurityHeaders;
 use NtMcp\Http\CorsHandler;
+use NtMcp\Http\IpAllowlist;
+use NtMcp\Security\RateLimiter;
 use NtMcp\OAuth\OAuthMigration;
 use NtMcp\OAuth\OAuthRouter;
 
 // SECURITY FIX (F1 -- audit): TLS enforcement (RFC 6749 §3.1)
 TlsEnforcer::enforce();
+
+// SECURITY CONTROL (9.4): Optional IP allowlist (WO-6)
+IpAllowlist::enforce();
+
+// SECURITY FIX (WO-6): IP-based rate limiting for OAuth entry points
+(new RateLimiter('nt_mcp_oauth_rl_', 60, 60))->enforce();
 
 // SECURITY FIX (F2 -- audit): Security response headers
 SecurityHeaders::emit();

--- a/modules/addons/nt_mcp/src/Auth/BearerAuth.php
+++ b/modules/addons/nt_mcp/src/Auth/BearerAuth.php
@@ -37,7 +37,7 @@ class BearerAuth
      * if the token is invalid/expired.  For static tokens the admin comes
      * from nt_mcp_bearer_token_admin; for OAuth tokens from the DB row.
      *
-     * Fallback chain: per-token admin_user → global nt_mcp_admin_user → 'admin'
+     * Fallback chain: per-token admin_user → global nt_mcp_admin_user → null (deny)
      */
     public function authenticate(): ?string
     {
@@ -75,7 +75,7 @@ class BearerAuth
     /**
      * Resolve admin username for the static bearer token.
      */
-    private function getStaticTokenAdmin(): string
+    private function getStaticTokenAdmin(): ?string
     {
         try {
             $admin = trim(\WHMCS\Config\Setting::getValue('nt_mcp_bearer_token_admin') ?? '');
@@ -142,9 +142,14 @@ class BearerAuth
     }
 
     /**
-     * Fallback admin resolution: global config → hardcoded 'admin'.
+     * Fallback admin resolution: global config → null (fail-closed).
+     *
+     * SECURITY FIX (WO-7): previously fell back to a hardcoded 'admin' when
+     * nt_mcp_admin_user was empty, silently binding every unconfigured token
+     * to the superadmin account. Now returns null so authenticate() denies
+     * the request (401) instead of granting superadmin access by default.
      */
-    private function getFallbackAdmin(): string
+    private function getFallbackAdmin(): ?string
     {
         try {
             $configured = trim(\WHMCS\Config\Setting::getValue('nt_mcp_admin_user') ?? '');
@@ -155,8 +160,8 @@ class BearerAuth
             error_log('NT MCP BearerAuth: Failed to read nt_mcp_admin_user: ' . $e->getMessage());
         }
 
-        error_log('NT MCP BearerAuth: WARNING - No admin_user configured, falling back to hardcoded "admin"');
-        return 'admin';
+        error_log('NT MCP BearerAuth: WARNING - No admin_user configured, denying (no fallback admin)');
+        return null;
     }
 
     /**

--- a/modules/addons/nt_mcp/src/Http/CorsHandler.php
+++ b/modules/addons/nt_mcp/src/Http/CorsHandler.php
@@ -13,18 +13,33 @@ namespace NtMcp\Http;
  * - nt_mcp_cors_origins set + HTTP_ORIGIN in list → specific origin + Vary: Origin
  * - nt_mcp_cors_origins set + HTTP_ORIGIN not in list → no CORS header (browser blocks)
  * - nt_mcp_cors_origins set + no HTTP_ORIGIN (CLI) → Access-Control-Allow-Origin: *
+ *
+ * Fail-closed on config-read error (E): a real error reading nt_mcp_cors_origins
+ * (e.g. DB failure) must NEVER be treated as "no allowlist configured" — that would
+ * silently degrade to Access-Control-Allow-Origin: * on infra failure. handle()
+ * responds 503 instead. See getAllowedOriginsOrFail(), mirrors IpAllowlist.php:20-28.
  */
 final class CorsHandler
 {
     /**
      * Emit CORS headers. Returns true if this was an OPTIONS preflight (caller should exit).
+     * Responds 503 + exits if the CORS origins config could not be read (fail closed).
      *
      * @param string[] $exposeHeaders Additional headers to expose
      */
     public static function handle(array $exposeHeaders = [], string $methods = 'GET, POST, OPTIONS'): bool
     {
         $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-        $allowedOrigins = self::getAllowedOrigins();
+        $allowedOrigins = self::getAllowedOriginsOrFail();
+
+        if ($allowedOrigins === false) {
+            // Config read failed (DB error etc.) — fail closed: deny rather than silently
+            // falling back to Access-Control-Allow-Origin: *.
+            http_response_code(503);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Service temporarily unavailable.']);
+            exit;
+        }
 
         $originHeader = self::resolveOriginHeader($origin, $allowedOrigins);
         if ($originHeader !== null) {
@@ -70,18 +85,41 @@ final class CorsHandler
 
     /**
      * Reads nt_mcp_cors_origins from WHMCS config (CSV of allowed origins).
-     * Returns empty array if not configured or on error → falls back to wildcard.
+     *
+     * Back-compat wrapper around getAllowedOriginsOrFail(): treats a real config-read
+     * error the same as "not configured" (empty array). Callers that need to
+     * distinguish the two (i.e. handle()) must use getAllowedOriginsOrFail() instead,
+     * since collapsing "error" into "empty" here would resolve to a wildcard origin.
      *
      * @return string[]
      */
     public static function getAllowedOrigins(): array
     {
+        $result = self::getAllowedOriginsOrFail();
+        return $result === false ? [] : $result;
+    }
+
+    /**
+     * Reads nt_mcp_cors_origins from WHMCS config (CSV of allowed origins).
+     *
+     * Unlike getAllowedOrigins(), distinguishes "not configured" ([]) from
+     * "config read failed" (false) so callers can fail closed (E) instead of
+     * silently falling back to Access-Control-Allow-Origin: *. Returns array|false
+     * rather than exiting directly so this stays unit-testable; the actual
+     * fail-closed response (503 + exit) is emitted by handle().
+     *
+     * @return string[]|false
+     */
+    public static function getAllowedOriginsOrFail()
+    {
         try {
             $raw = \WHMCS\Config\Setting::getValue('nt_mcp_cors_origins') ?? '';
-            $origins = array_filter(array_map('trim', explode(',', $raw)));
-            return array_values($origins);
         } catch (\Throwable $e) {
-            return [];
+            error_log('NT MCP CorsHandler: Failed to read CORS origins config: ' . $e->getMessage());
+            return false;
         }
+
+        $origins = array_filter(array_map('trim', explode(',', $raw)));
+        return array_values($origins);
     }
 }

--- a/modules/addons/nt_mcp/src/Http/IpResolver.php
+++ b/modules/addons/nt_mcp/src/Http/IpResolver.php
@@ -7,16 +7,64 @@ namespace NtMcp\Http;
 /**
  * SECURITY FIX (M-01): Resolve the real client IP behind reverse proxies.
  *
- * When REMOTE_ADDR is a loopback address or matches a configured trusted
- * proxy, the rightmost untrusted IP from X-Forwarded-For is used instead.
- * This prevents rate-limit bypass and ensures IP allowlists work correctly
- * behind Plesk/nginx reverse proxies.
+ * Unification (WO-TP): prefer the client IP that WHMCS itself resolves via its
+ * native Trusted Proxies configuration (Configuration > General Settings >
+ * Security tab), so the addon's IP allowlist / rate-limiter key on the same IP
+ * WHMCS logs and bans. A coherence guard prevents a directly-connected attacker
+ * from spoofing a forwarded header. When the native path is unavailable the
+ * previous rightmost-untrusted X-Forwarded-For algorithm is used unchanged.
+ *
+ * isTrustedProxy() trusts loopback plus the union of the native WHMCS proxy
+ * list (TrustedProxyIps) and the addon's own nt_mcp_trusted_proxies (now
+ * additive/optional). Any parse failure degrades to loopback-only — never
+ * fail-open.
  */
 final class IpResolver
 {
+    /** @var callable|null test hook: fn(): ?string — the WHMCS-resolved client IP */
+    private static $nativeIpResolver = null;
+
+    /** @var callable|null test hook: fn(string $key): mixed — raw config reader */
+    private static $configReader = null;
+
+    /** @var string[]|null per-request cache of the merged trusted-proxy list */
+    private static ?array $trustedProxiesCache = null;
+
+    public static function setNativeIpResolverForTests(?callable $fn): void
+    {
+        self::$nativeIpResolver = $fn;
+    }
+
+    public static function setConfigReaderForTests(?callable $fn): void
+    {
+        self::$configReader = $fn;
+        self::$trustedProxiesCache = null;
+    }
+
+    public static function resetForTests(): void
+    {
+        self::$nativeIpResolver = null;
+        self::$configReader = null;
+        self::$trustedProxiesCache = null;
+    }
+
     public static function resolve(): string
     {
         $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
+
+        // Unification (WO-TP): prefer the IP WHMCS itself resolves — it honours
+        // the native Trusted Proxy List and Proxy IP Header (Security tab).
+        // COHERENCE GUARD: only accept the native value when it equals
+        // REMOTE_ADDR (no proxy in the path) or REMOTE_ADDR is a trusted proxy
+        // by the merged list. Otherwise a directly-connected attacker could
+        // spoof a forwarded header (e.g. XFF: 10.0.0.5) to slip into the IP
+        // allowlist or rotate the rate-limiter key — fall through to the
+        // conservative algorithm below.
+        $native = self::nativeClientIp();
+        if ($native !== null && ($native === $remoteAddr || self::isTrustedProxy($remoteAddr))) {
+            return $native;
+        }
+
         if ($remoteAddr === '') {
             return '0.0.0.0';
         }
@@ -55,9 +103,41 @@ final class IpResolver
     }
 
     /**
+     * The client IP resolved by the WHMCS core (which applies the native
+     * Trusted Proxy List and Proxy IP Header), or null if unavailable/invalid
+     * so resolve() falls back to its own algorithm.
+     */
+    private static function nativeClientIp(): ?string
+    {
+        try {
+            if (self::$nativeIpResolver !== null) {
+                $ip = (self::$nativeIpResolver)();
+            } elseif (class_exists('\App') && is_callable(['\App', 'getClientIp'])) {
+                $ip = \App::getClientIp();
+            } else {
+                return null;
+            }
+
+            if (!is_string($ip)) {
+                return null;
+            }
+            $ip = trim($ip);
+            // '0.0.0.0' would trip IpAllowlist's empty-IP 403 — treat as null.
+            if ($ip === '' || $ip === '0.0.0.0' || !filter_var($ip, FILTER_VALIDATE_IP)) {
+                return null;
+            }
+            return $ip;
+        } catch (\Throwable $e) {
+            error_log('NT MCP: native client IP resolution failed: ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
      * SECURITY FIX (WO-4): Check whether an IP is a trusted proxy — loopback
-     * (always trusted) or present in the configured nt_mcp_trusted_proxies list,
-     * which may contain exact IPs or CIDR ranges (e.g. "10.0.0.0/8").
+     * (always trusted) or present in the merged proxy list (WHMCS native
+     * TrustedProxyIps ∪ addon nt_mcp_trusted_proxies), which may contain exact
+     * IPs or CIDR ranges (e.g. "10.0.0.0/8").
      */
     public static function isTrustedProxy(string $ip): bool
     {
@@ -65,21 +145,7 @@ final class IpResolver
             return true;
         }
 
-        $trustedProxies = [];
-        try {
-            $configured = \WHMCS\Config\Setting::getValue('nt_mcp_trusted_proxies') ?? '';
-            if ($configured !== '') {
-                $trustedProxies = array_filter(array_map('trim', explode(',', $configured)));
-            }
-        } catch (\Throwable $e) {
-            // SECURITY FIX (F-05): Log config load failures
-            error_log('NT MCP: Failed to load nt_mcp_trusted_proxies: ' . $e->getMessage());
-        }
-
-        foreach ($trustedProxies as $entry) {
-            if ($entry === '') {
-                continue;
-            }
+        foreach (self::trustedProxies() as $entry) {
             if (str_contains($entry, '/')) {
                 if (self::isInCidr($ip, $entry)) {
                     return true;
@@ -90,6 +156,121 @@ final class IpResolver
         }
 
         return false;
+    }
+
+    /**
+     * Merged, per-request-cached trusted-proxy list: the addon's own
+     * nt_mcp_trusted_proxies (additive/optional) ∪ the WHMCS native
+     * TrustedProxyIps. isTrustedProxy() is called many times per request
+     * (TlsEnforcer twice + the resolve() walk), so the parsed list is cached.
+     *
+     * @return string[]
+     */
+    private static function trustedProxies(): array
+    {
+        if (self::$trustedProxiesCache !== null) {
+            return self::$trustedProxiesCache;
+        }
+
+        $own = self::parseProxyList(self::readSetting('nt_mcp_trusted_proxies'));
+        $native = self::parseProxyList(self::readSetting('TrustedProxyIps'));
+
+        // Observability: XFF present but no trusted proxies configured anywhere
+        // is a likely unification no-op (native key named differently on this
+        // WHMCS version?) — surface it instead of silently trusting nothing.
+        if ($own === [] && $native === [] && !empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            error_log('NT MCP: X-Forwarded-For present but no trusted proxies configured '
+                . '(nt_mcp_trusted_proxies empty; WHMCS TrustedProxyIps not found/empty) — only loopback trusted');
+        }
+
+        return self::$trustedProxiesCache = array_values(array_unique(array_merge($own, $native)));
+    }
+
+    /**
+     * Read a WHMCS config value (via the test hook when set). Any Throwable is
+     * swallowed and null returned — a config read failure must never fail-open
+     * into an empty (loopback-only) trusted list without a log trail.
+     */
+    private static function readSetting(string $key): mixed
+    {
+        try {
+            if (self::$configReader !== null) {
+                return (self::$configReader)($key);
+            }
+            return \WHMCS\Config\Setting::getValue($key);
+        } catch (\Throwable $e) {
+            // SECURITY FIX (F-05): Log config load failures
+            error_log("NT MCP: Failed to load {$key}: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Normalise a proxy-list config value into a list of syntactically VALID
+     * IPs/CIDRs. The native TrustedProxyIps storage format is undocumented, so
+     * every plausible shape is accepted: an already-decoded array (getValue may
+     * return one); a JSON array of strings or of objects ({ip, note, ...}); a
+     * PHP-serialized array (allowed_classes=false, only when prefixed "a:"); or
+     * plain CSV/newline text. Anything unrecognised or invalid is dropped — an
+     * unparseable value never degrades into "trust everything".
+     *
+     * @return string[]
+     */
+    private static function parseProxyList(mixed $raw): array
+    {
+        if ($raw === null || $raw === '' || $raw === []) {
+            return [];
+        }
+
+        $items = null;
+        if (is_array($raw)) {
+            $items = $raw;
+        } elseif (is_string($raw)) {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                $items = $decoded;
+            } elseif (str_starts_with($raw, 'a:')) {
+                $unserialized = @unserialize($raw, ['allowed_classes' => false]);
+                if (is_array($unserialized)) {
+                    $items = $unserialized;
+                }
+            }
+            if ($items === null) {
+                $items = preg_split('/[,\r\n]+/', $raw) ?: [];
+            }
+        } else {
+            return [];
+        }
+
+        $out = [];
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                $item = $item['ip'] ?? '';
+            }
+            if (!is_string($item)) {
+                continue;
+            }
+            $item = trim($item);
+            if ($item !== '' && self::isValidProxyEntry($item)) {
+                $out[] = $item;
+            }
+        }
+        return $out;
+    }
+
+    /** An entry must be a valid IP or a valid CIDR — never an arbitrary string. */
+    private static function isValidProxyEntry(string $entry): bool
+    {
+        if (str_contains($entry, '/')) {
+            $parts = explode('/', $entry, 2);
+            if (count($parts) !== 2) {
+                return false;
+            }
+            [$subnet, $bits] = $parts;
+            return $bits !== '' && ctype_digit($bits)
+                && filter_var($subnet, FILTER_VALIDATE_IP) !== false;
+        }
+        return filter_var($entry, FILTER_VALIDATE_IP) !== false;
     }
 
     /**

--- a/modules/addons/nt_mcp/src/Http/IpResolver.php
+++ b/modules/addons/nt_mcp/src/Http/IpResolver.php
@@ -81,22 +81,30 @@ final class IpResolver
         }
 
         $ips = array_map('trim', explode(',', $xff));
-        // Walk from right to left, return first IP not in trusted list
+        // Walk from right to left, peeling off trusted proxies. The FIRST
+        // untrusted hop is the real client and terminates the chain of trust —
+        // everything to its left is attacker-controlled, so the scan must never
+        // continue past it (SECURITY: stop at the first untrusted hop, else a
+        // forged leftmost XFF value could be returned).
         for ($i = count($ips) - 1; $i >= 0; $i--) {
             $ip = $ips[$i];
             if ($ip === '') {
                 continue;
             }
-            // SECURITY FIX (WO-4): reject private/reserved-range IPs from the
-            // client-facing XFF entry (spoofable, never a legitimate public client).
-            // This flag is intentionally applied only here, not to the trusted-proxy
-            // match below, since configured trusted proxies are commonly private IPs.
-            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+            // Trusted proxies (commonly private IPs) are peeled off; the private/
+            // reserved-range check below is intentionally applied only to the
+            // untrusted client hop, not to this trusted-proxy match.
+            if (self::isTrustedProxy($ip)) {
                 continue;
             }
-            if (!self::isTrustedProxy($ip)) {
+            // First untrusted hop = the real client. Accept it only when it is a
+            // valid PUBLIC IP; a private/reserved/malformed value here is spoofed
+            // (a legitimate public client is never private), so stop and fall
+            // back to REMOTE_ADDR instead of walking further left.
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
                 return $ip;
             }
+            break;
         }
 
         return $remoteAddr;

--- a/modules/addons/nt_mcp/src/Http/IpResolver.php
+++ b/modules/addons/nt_mcp/src/Http/IpResolver.php
@@ -22,21 +22,7 @@ final class IpResolver
         }
 
         // Check if REMOTE_ADDR is a trusted proxy (loopback or configured list)
-        $trustedProxies = ['127.0.0.1', '::1'];
-        try {
-            $configured = \WHMCS\Config\Setting::getValue('nt_mcp_trusted_proxies') ?? '';
-            if ($configured !== '') {
-                $trustedProxies = array_merge(
-                    $trustedProxies,
-                    array_filter(array_map('trim', explode(',', $configured)))
-                );
-            }
-        } catch (\Throwable $e) {
-            // SECURITY FIX (F-05): Log config load failures
-            error_log('NT MCP: Failed to load nt_mcp_trusted_proxies: ' . $e->getMessage());
-        }
-
-        if (!in_array($remoteAddr, $trustedProxies, true)) {
+        if (!self::isTrustedProxy($remoteAddr)) {
             return $remoteAddr;
         }
 
@@ -50,12 +36,60 @@ final class IpResolver
         // Walk from right to left, return first IP not in trusted list
         for ($i = count($ips) - 1; $i >= 0; $i--) {
             $ip = $ips[$i];
-            if ($ip !== '' && filter_var($ip, FILTER_VALIDATE_IP) && !in_array($ip, $trustedProxies, true)) {
+            if ($ip === '') {
+                continue;
+            }
+            // SECURITY FIX (WO-4): reject private/reserved-range IPs from the
+            // client-facing XFF entry (spoofable, never a legitimate public client).
+            // This flag is intentionally applied only here, not to the trusted-proxy
+            // match below, since configured trusted proxies are commonly private IPs.
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                continue;
+            }
+            if (!self::isTrustedProxy($ip)) {
                 return $ip;
             }
         }
 
         return $remoteAddr;
+    }
+
+    /**
+     * SECURITY FIX (WO-4): Check whether an IP is a trusted proxy — loopback
+     * (always trusted) or present in the configured nt_mcp_trusted_proxies list,
+     * which may contain exact IPs or CIDR ranges (e.g. "10.0.0.0/8").
+     */
+    public static function isTrustedProxy(string $ip): bool
+    {
+        if ($ip === '127.0.0.1' || $ip === '::1') {
+            return true;
+        }
+
+        $trustedProxies = [];
+        try {
+            $configured = \WHMCS\Config\Setting::getValue('nt_mcp_trusted_proxies') ?? '';
+            if ($configured !== '') {
+                $trustedProxies = array_filter(array_map('trim', explode(',', $configured)));
+            }
+        } catch (\Throwable $e) {
+            // SECURITY FIX (F-05): Log config load failures
+            error_log('NT MCP: Failed to load nt_mcp_trusted_proxies: ' . $e->getMessage());
+        }
+
+        foreach ($trustedProxies as $entry) {
+            if ($entry === '') {
+                continue;
+            }
+            if (str_contains($entry, '/')) {
+                if (self::isInCidr($ip, $entry)) {
+                    return true;
+                }
+            } elseif ($entry === $ip) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/modules/addons/nt_mcp/src/Http/TlsEnforcer.php
+++ b/modules/addons/nt_mcp/src/Http/TlsEnforcer.php
@@ -13,24 +13,79 @@ final class TlsEnforcer
 {
     public static function enforce(): void
     {
-        $isHttps = (
+        if (self::isRequestSecure()) {
+            return;
+        }
+
+        if (self::isHttpBypassAllowed()) {
+            return;
+        }
+
+        http_response_code(421);
+        header('Content-Type: application/json');
+        echo json_encode([
+            'error' => 'TLS required. Plain HTTP requests are rejected for security.',
+        ]);
+        exit;
+    }
+
+    /**
+     * SECURITY FIX (WO-4): Pure decision logic, side-effect free, so it can be
+     * unit-tested without triggering enforce()'s exit.
+     */
+    public static function isRequestSecure(): bool
+    {
+        $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
+
+        return (
             (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
             || (isset($_SERVER['SERVER_PORT']) && (int)$_SERVER['SERVER_PORT'] === 443)
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
+            || (
+                isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+                && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https'
+                // SECURITY FIX (WO-4): only a trusted proxy may assert the
+                // original scheme via X-Forwarded-Proto; otherwise it is spoofable.
+                && IpResolver::isTrustedProxy($remoteAddr)
+            )
         );
+    }
 
-        $allowHttp = (
+    /**
+     * SECURITY FIX (WO-4): NT_MCP_ALLOW_HTTP is only honored when the request
+     * comes from a trusted proxy or a loopback/private REMOTE_ADDR — never for
+     * arbitrary internet clients. Every time the bypass is actually granted,
+     * it is logged.
+     */
+    public static function isHttpBypassAllowed(): bool
+    {
+        $envAllows = (
             getenv('NT_MCP_ALLOW_HTTP') === '1'
             || (isset($_ENV['NT_MCP_ALLOW_HTTP']) && $_ENV['NT_MCP_ALLOW_HTTP'] === '1')
         );
 
-        if (!$isHttps && !$allowHttp) {
-            http_response_code(421);
-            header('Content-Type: application/json');
-            echo json_encode([
-                'error' => 'TLS required. Plain HTTP requests are rejected for security.',
-            ]);
-            exit;
+        if (!$envAllows) {
+            return false;
         }
+
+        $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
+        $trusted = IpResolver::isTrustedProxy($remoteAddr) || self::isLoopbackOrPrivate($remoteAddr);
+
+        if ($trusted) {
+            error_log('NT MCP: TLS enforcement bypassed via NT_MCP_ALLOW_HTTP from ' . $remoteAddr);
+        }
+
+        return $trusted;
+    }
+
+    private static function isLoopbackOrPrivate(string $ip): bool
+    {
+        if ($ip === '127.0.0.1' || $ip === '::1') {
+            return true;
+        }
+        if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        return !filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
     }
 }

--- a/modules/addons/nt_mcp/src/Server.php
+++ b/modules/addons/nt_mcp/src/Server.php
@@ -69,8 +69,12 @@ class Server
             return;
         }
 
-        $input = file_get_contents('php://input');
-        if (strlen($input) > 1048576) {
+        // Read at most 1 MB + 1 byte so an oversized body is rejected without
+        // materializing the whole payload (covers missing/incorrect Content-Length
+        // and chunked Transfer-Encoding). The header guard above still runs first.
+        $maxBytes = 1048576; // 1 MB
+        $input = (string) file_get_contents('php://input', false, null, 0, $maxBytes + 1);
+        if (strlen($input) > $maxBytes) {
             http_response_code(413);
             header('Content-Type: application/json');
             echo json_encode(['error' => 'Request body too large (max 1 MB)']);

--- a/modules/addons/nt_mcp/src/Server.php
+++ b/modules/addons/nt_mcp/src/Server.php
@@ -19,17 +19,27 @@ class Server
     {
         // ------------------------------------------------------------------
         // Admin user resolution: prefer per-token admin from authenticate(),
-        // fall back to global config, then hardcoded 'admin'.
+        // fall back to global config. SECURITY (WO-7 consistency): if none is
+        // resolvable, fail CLOSED (401) instead of binding the superadmin
+        // 'admin' — mirrors BearerAuth::getFallbackAdmin(). In practice mcp.php
+        // never calls run() with an empty admin (authenticate() denies first),
+        // so this only closes a latent inconsistency.
         // ------------------------------------------------------------------
         if ($adminUser === '') {
-            $adminUser = 'admin';
             try {
                 $configured = trim(\WHMCS\Config\Setting::getValue('nt_mcp_admin_user') ?? '');
                 if ($configured !== '') {
                     $adminUser = $configured;
                 }
             } catch (\Throwable $_ex) {
-                // Setting not available — use default
+                // Setting not available — leave empty to deny below
+            }
+            if ($adminUser === '') {
+                error_log('NT MCP Server: no admin user resolved and none configured — denying request');
+                http_response_code(401);
+                header('Content-Type: application/json');
+                echo json_encode(['error' => 'Unauthorized: no admin user configured']);
+                return;
             }
         }
 

--- a/modules/addons/nt_mcp/src/Server.php
+++ b/modules/addons/nt_mcp/src/Server.php
@@ -70,6 +70,12 @@ class Server
         }
 
         $input = file_get_contents('php://input');
+        if (strlen($input) > 1048576) {
+            http_response_code(413);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Request body too large (max 1 MB)']);
+            return;
+        }
         $decoded = json_decode($input, true);
 
         // ------------------------------------------------------------------

--- a/modules/addons/nt_mcp/src/Tools/BillingTools.php
+++ b/modules/addons/nt_mcp/src/Tools/BillingTools.php
@@ -3,6 +3,7 @@
 namespace NtMcp\Tools;
 
 use NtMcp\Whmcs\LocalApiClient;
+use NtMcp\Whmcs\ResponseRedactor;
 use PhpMcp\Server\Attributes\McpTool;
 
 class BillingTools
@@ -210,12 +211,7 @@ class BillingTools
     public function getPayMethods(int $clientid): string
     {
         $result = $this->api->call('GetPayMethods', ['clientid' => $clientid]);
-        if (isset($result['paymethods'])) {
-            foreach ($result['paymethods'] as &$pm) {
-                unset($pm['gateway_customer_id'], $pm['token'], $pm['card_number']);
-            }
-            unset($pm);
-        }
+        ResponseRedactor::stripPayMethods($result);
         return json_encode($result, JSON_PRETTY_PRINT);
     }
 }

--- a/modules/addons/nt_mcp/src/Tools/ClientTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ClientTools.php
@@ -3,6 +3,7 @@
 namespace NtMcp\Tools;
 
 use NtMcp\Whmcs\LocalApiClient;
+use NtMcp\Whmcs\ResponseRedactor;
 use PhpMcp\Server\Attributes\McpTool;
 
 class ClientTools
@@ -36,10 +37,9 @@ class ClientTools
     )]
     public function getClient(int $clientid): string
     {
-        return json_encode(
-            $this->api->call('GetClientsDetails', ['clientid' => $clientid, 'stats' => true]),
-            JSON_PRETTY_PRINT
-        );
+        $result = $this->api->call('GetClientsDetails', ['clientid' => $clientid, 'stats' => true]);
+        ResponseRedactor::stripClientDetails($result);
+        return json_encode($result, JSON_PRETTY_PRINT);
     }
 
     #[McpTool(
@@ -164,18 +164,8 @@ class ClientTools
     public function getClientProducts(int $clientid): string
     {
         $result = $this->api->call('GetClientsProducts', ['clientid' => $clientid]);
-        self::stripProductPasswords($result);
+        ResponseRedactor::stripProductPasswords($result);
         return json_encode($result, JSON_PRETTY_PRINT);
-    }
-
-    private static function stripProductPasswords(array &$result): void
-    {
-        if (isset($result['products']['product'])) {
-            foreach ($result['products']['product'] as &$p) {
-                unset($p['password']);
-            }
-            unset($p);
-        }
     }
 
     #[McpTool(name: 'whmcs_get_client_domains', description: 'Lista domínios de um cliente')]

--- a/modules/addons/nt_mcp/src/Tools/ServiceTools.php
+++ b/modules/addons/nt_mcp/src/Tools/ServiceTools.php
@@ -3,6 +3,7 @@
 namespace NtMcp\Tools;
 
 use NtMcp\Whmcs\LocalApiClient;
+use NtMcp\Whmcs\ResponseRedactor;
 use PhpMcp\Server\Attributes\McpTool;
 
 class ServiceTools
@@ -17,18 +18,8 @@ class ServiceTools
         if ($limitstart > 0) $params['limitstart'] = $limitstart;
         if ($pid > 0) $params['pid'] = $pid;
         $result = $this->api->call('GetClientsProducts', $params);
-        self::stripProductPasswords($result);
+        ResponseRedactor::stripProductPasswords($result);
         return json_encode($result, JSON_PRETTY_PRINT);
-    }
-
-    private static function stripProductPasswords(array &$result): void
-    {
-        if (isset($result['products']['product'])) {
-            foreach ($result['products']['product'] as &$p) {
-                unset($p['password']);
-            }
-            unset($p);
-        }
     }
 
     #[McpTool(name: 'whmcs_suspend_service', description: 'Suspende um serviço de hospedagem/servidor')]

--- a/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
@@ -93,6 +93,11 @@ class CapsuleClient
      */
     private function isReadonly(): bool
     {
+        // Fora de um WHMCS bootstrapado (ex.: testes) não há config a proteger.
+        // Sob WHMCS, uma falha de leitura cai no catch e falha FECHADO.
+        if (!class_exists('\WHMCS\Config\Setting')) {
+            return false;
+        }
         try {
             $v = \WHMCS\Config\Setting::getValue('nt_mcp_readonly');
             return $v === '1' || $v === 1 || $v === true;

--- a/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
@@ -69,6 +69,24 @@ class CapsuleClient
         }
     }
 
+    private function assertWritable(): void
+    {
+        $readonly = $this->boolCfg('nt_mcp_readonly', false);
+        $writeOn  = $this->boolCfg('nt_mcp_enable_write', true);
+        if ($readonly || !$writeOn) {
+            throw new \InvalidArgumentException('CapsuleClient: writes disabled (read-only / write gate).');
+        }
+    }
+
+    private function boolCfg(string $key, bool $default): bool
+    {
+        try {
+            $v = \WHMCS\Database\Capsule::connection() ? \WHMCS\Config\Setting::getValue($key) : null;
+            if ($v === null || $v === '') return $default;
+            return $v === '1' || $v === 1 || $v === true;
+        } catch (\Throwable $e) { return $default; }
+    }
+
     /**
      * Validates that every key in $data is present in the column allowlist
      * for the given table and operation.
@@ -131,6 +149,7 @@ class CapsuleClient
     public function insert(string $table, array $data): int
     {
         $this->assertTableAllowed($table);
+        $this->assertWritable();
         $this->assertColumnsAllowed($table, $data, self::ALLOWED_COLUMNS[$table]);
 
         // SECURITY FIX (F8): Audit log for DB writes
@@ -142,6 +161,7 @@ class CapsuleClient
     public function update(string $table, array $where, array $data): int
     {
         $this->assertTableAllowed($table);
+        $this->assertWritable();
         $this->assertColumnsAllowed($table, $where, self::ALLOWED_WHERE_COLUMNS[$table]);
         $this->assertColumnsAllowed($table, $data, self::ALLOWED_COLUMNS[$table]);
 
@@ -161,6 +181,7 @@ class CapsuleClient
     public function delete(string $table, array $where): int
     {
         $this->assertTableAllowed($table);
+        $this->assertWritable();
         $this->assertColumnsAllowed($table, $where, self::ALLOWED_WHERE_COLUMNS[$table]);
 
         if ($where === []) {

--- a/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/CapsuleClient.php
@@ -69,19 +69,43 @@ class CapsuleClient
         }
     }
 
+    /** Override do gate de escrita para testes (null = usa config WHMCS). */
+    private ?bool $writableOverride = null;
+    public function setWritableForTests(bool $writable): void { $this->writableOverride = $writable; }
+
     private function assertWritable(): void
     {
-        $readonly = $this->boolCfg('nt_mcp_readonly', false);
-        $writeOn  = $this->boolCfg('nt_mcp_enable_write', true);
-        if ($readonly || !$writeOn) {
+        if ($this->writableOverride !== null) {
+            if (!$this->writableOverride) {
+                throw new \InvalidArgumentException('CapsuleClient: writes disabled (read-only / write gate).');
+            }
+            return;
+        }
+        if ($this->isReadonly() || !$this->boolCfg('nt_mcp_enable_write', true)) {
             throw new \InvalidArgumentException('CapsuleClient: writes disabled (read-only / write gate).');
+        }
+    }
+
+    /**
+     * readonly master switch — FAIL-CLOSED: qualquer falha de leitura de config
+     * é tratada como read-only (bloqueia escrita), para não liberar writes num
+     * ambiente que deveria permanecer somente-leitura.
+     */
+    private function isReadonly(): bool
+    {
+        try {
+            $v = \WHMCS\Config\Setting::getValue('nt_mcp_readonly');
+            return $v === '1' || $v === 1 || $v === true;
+        } catch (\Throwable $e) {
+            error_log('NT MCP CapsuleClient: readonly config read failed — failing closed: ' . $e->getMessage());
+            return true;
         }
     }
 
     private function boolCfg(string $key, bool $default): bool
     {
         try {
-            $v = \WHMCS\Database\Capsule::connection() ? \WHMCS\Config\Setting::getValue($key) : null;
+            $v = \WHMCS\Config\Setting::getValue($key);
             if ($v === null || $v === '') return $default;
             return $v === '1' || $v === 1 || $v === true;
         } catch (\Throwable $e) { return $default; }

--- a/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
@@ -153,14 +153,14 @@ class LocalApiClient
         'DomainUpdateNameservers'=>'WRITE','UpdateClientDomain'=>'WRITE','UpdateToDoItem'=>'WRITE',
         'LogActivity'=>'WRITE','CreateProject'=>'WRITE','UpdateProject'=>'WRITE','AddProjectTask'=>'WRITE',
         'UpdateProjectTask'=>'WRITE','StartTaskTimer'=>'WRITE','EndTaskTimer'=>'WRITE',
-        'AddProjectMessage'=>'WRITE','CreateQuote'=>'WRITE','UpdateQuote'=>'WRITE','AcceptQuote'=>'WRITE',
+        'AddProjectMessage'=>'WRITE','CreateQuote'=>'WRITE','UpdateQuote'=>'WRITE',
         // DESTRUCTIVE (irreversível)
         'CloseClient'=>'DESTRUCTIVE','ModuleTerminate'=>'DESTRUCTIVE','DeleteOrder'=>'DESTRUCTIVE',
         'DeleteProjectTask'=>'DESTRUCTIVE',
-        // FINANCIAL
+        // FINANCIAL — AcceptQuote gera fatura/pedido, logo é efeito financeiro
         'CreateInvoice'=>'FINANCIAL','AddInvoicePayment'=>'FINANCIAL','UpdateInvoice'=>'FINANCIAL',
         'AddCredit'=>'FINANCIAL','AddTransaction'=>'FINANCIAL','UpdateTransaction'=>'FINANCIAL',
-        'AddBillableItem'=>'FINANCIAL',
+        'AddBillableItem'=>'FINANCIAL','AcceptQuote'=>'FINANCIAL',
         // COST (custo/provisionamento externo)
         'DomainRegister'=>'COST','DomainRenew'=>'COST','UpgradeProduct'=>'COST',
         'AcceptOrder'=>'COST','AddOrder'=>'COST',

--- a/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
@@ -173,10 +173,11 @@ class LocalApiClient
 
     private ?array $gatesOverride = null; // teste: ['write'=>bool,'destructive'=>bool,...,'readonly'=>bool]
     private const IMPERSONATION_COMMANDS = [
-        'AddTicketReply','CreateProject','AddProjectTask','StartTaskTimer',
-        'EndTaskTimer','AddProjectMessage','UpdateToDoItem',
+        'AddTicketReply','CreateProject','UpdateProject','AddProjectTask',
+        'UpdateProjectTask','StartTaskTimer','EndTaskTimer','AddProjectMessage',
+        'UpdateToDoItem',
     ];
-    private static array $adminIdCache = [];
+    private array $adminIdCache = [];
     private $adminIdResolver = null; // teste: fn(string $username): ?int
 
     public function __construct(private readonly string $adminUser = 'admin') {}
@@ -259,16 +260,16 @@ class LocalApiClient
 
     private function resolveAdminId(string $username): ?int
     {
-        if (array_key_exists($username, self::$adminIdCache)) return self::$adminIdCache[$username];
+        if (array_key_exists($username, $this->adminIdCache)) return $this->adminIdCache[$username];
         if ($this->adminIdResolver !== null) {
             $id = ($this->adminIdResolver)($username);
-            if ($id !== null) self::$adminIdCache[$username] = $id;
+            if ($id !== null) $this->adminIdCache[$username] = $id;
             return $id;
         }
         try {
             $row = \WHMCS\Database\Capsule::table('tbladmins')->where('username', $username)->first();
             $id = $row ? (int) $row->id : null;
-            if ($id !== null) self::$adminIdCache[$username] = $id;
+            if ($id !== null) $this->adminIdCache[$username] = $id;
             return $id;
         } catch (\Throwable $e) {
             error_log('NT MCP: resolveAdminId failed: ' . $e->getMessage());
@@ -328,7 +329,7 @@ class LocalApiClient
             );
         }
 
-        \NtMcp\Whmcs\ResponseRedactor::scrubSensitive($result);  // D defense-in-depth
+        ResponseRedactor::scrubSensitive($result);  // D defense-in-depth
 
         return $result;
     }

--- a/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
@@ -199,7 +199,7 @@ class LocalApiClient
     private function gateEnabled(string $class): bool
     {
         if ($class === 'READ') return true;
-        if ($this->boolSetting('nt_mcp_readonly', false, 'readonly')) return false; // master switch
+        if ($this->isReadonly()) return false; // master switch (fail-closed)
         [$key, $default] = match ($class) {
             'WRITE'       => ['nt_mcp_enable_write', true],   // WRITE habilitado por padrão
             'DESTRUCTIVE' => ['nt_mcp_enable_destructive', false],
@@ -209,6 +209,31 @@ class LocalApiClient
             default       => ['nt_mcp_enable_write', false],
         };
         return $this->boolSetting($key, $default, strtolower($class));
+    }
+
+    /**
+     * readonly master switch — FAIL-CLOSED: qualquer falha de leitura de config
+     * é tratada como read-only (bloqueia escrita), consistente com
+     * CapsuleClient::isReadonly(). O override de teste tem precedência.
+     */
+    private function isReadonly(): bool
+    {
+        if ($this->gatesOverride !== null) {
+            return (bool) ($this->gatesOverride['readonly'] ?? false);
+        }
+        // Fora de um WHMCS bootstrapado (ex.: testes) não há config a proteger —
+        // usa o default seguro. Sob WHMCS, uma falha de leitura cai no catch
+        // abaixo e falha FECHADO (bloqueia escrita).
+        if (!class_exists('\WHMCS\Config\Setting')) {
+            return false;
+        }
+        try {
+            $v = \WHMCS\Config\Setting::getValue('nt_mcp_readonly');
+            return $v === '1' || $v === 1 || $v === true;
+        } catch (\Throwable $e) {
+            error_log('NT MCP LocalApiClient: readonly config read failed — failing closed: ' . $e->getMessage());
+            return true;
+        }
     }
 
     /** Lê config booleana com override de teste e default seguro. */

--- a/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
+++ b/modules/addons/nt_mcp/src/Whmcs/LocalApiClient.php
@@ -130,14 +130,150 @@ class LocalApiClient
         'securityqans', 'tax_id',
     ];
 
+    /** Classe de efeito colateral por comando. Fail-safe: ausente ⇒ WRITE. */
+    private const COMMAND_CLASS = [
+        // READ
+        'GetClients'=>'READ','GetClientsDetails'=>'READ','GetClientsProducts'=>'READ',
+        'GetClientsDomains'=>'READ','GetContacts'=>'READ','GetClientGroups'=>'READ',
+        'GetClientsAddons'=>'READ','GetInvoices'=>'READ','GetInvoice'=>'READ',
+        'GetTransactions'=>'READ','GetCredits'=>'READ','GetPayMethods'=>'READ',
+        'GetTickets'=>'READ','GetTicket'=>'READ','GetOrders'=>'READ','GetOrderStatuses'=>'READ',
+        'GetProducts'=>'READ','GetPromotions'=>'READ','DomainGetNameservers'=>'READ',
+        'DomainGetLockingStatus'=>'READ','DomainGetWhoisInfo'=>'READ','GetTLDPricing'=>'READ',
+        'GetStats'=>'READ','GetActivityLog'=>'READ','GetAdminDetails'=>'READ','GetCurrencies'=>'READ',
+        'GetEmailTemplates'=>'READ','GetPaymentMethods'=>'READ','GetToDoItems'=>'READ',
+        'GetToDoItemStatuses'=>'READ','GetProjects'=>'READ','GetProject'=>'READ','GetQuotes'=>'READ',
+        'GetSupportDepartments'=>'READ','GetSupportStatuses'=>'READ','GetTicketCounts'=>'READ',
+        'GetTicketNotes'=>'READ','GetTicketPredefinedCats'=>'READ','GetTicketPredefinedReplies'=>'READ',
+        'GetTicketAttachment'=>'READ',
+        // WRITE (reversível)
+        'AddClient'=>'WRITE','UpdateClient'=>'WRITE','AddContact'=>'WRITE','UpdateContact'=>'WRITE',
+        'ModuleSuspend'=>'WRITE','ModuleUnsuspend'=>'WRITE','OpenTicket'=>'WRITE',
+        'AddTicketReply'=>'WRITE','UpdateTicket'=>'WRITE','CancelOrder'=>'WRITE','PendingOrder'=>'WRITE',
+        'DomainUpdateNameservers'=>'WRITE','UpdateClientDomain'=>'WRITE','UpdateToDoItem'=>'WRITE',
+        'LogActivity'=>'WRITE','CreateProject'=>'WRITE','UpdateProject'=>'WRITE','AddProjectTask'=>'WRITE',
+        'UpdateProjectTask'=>'WRITE','StartTaskTimer'=>'WRITE','EndTaskTimer'=>'WRITE',
+        'AddProjectMessage'=>'WRITE','CreateQuote'=>'WRITE','UpdateQuote'=>'WRITE','AcceptQuote'=>'WRITE',
+        // DESTRUCTIVE (irreversível)
+        'CloseClient'=>'DESTRUCTIVE','ModuleTerminate'=>'DESTRUCTIVE','DeleteOrder'=>'DESTRUCTIVE',
+        'DeleteProjectTask'=>'DESTRUCTIVE',
+        // FINANCIAL
+        'CreateInvoice'=>'FINANCIAL','AddInvoicePayment'=>'FINANCIAL','UpdateInvoice'=>'FINANCIAL',
+        'AddCredit'=>'FINANCIAL','AddTransaction'=>'FINANCIAL','UpdateTransaction'=>'FINANCIAL',
+        'AddBillableItem'=>'FINANCIAL',
+        // COST (custo/provisionamento externo)
+        'DomainRegister'=>'COST','DomainRenew'=>'COST','UpgradeProduct'=>'COST',
+        'AcceptOrder'=>'COST','AddOrder'=>'COST',
+        // COMMS (envio de e-mail)
+        'SendEmail'=>'COMMS','SendQuote'=>'COMMS',
+    ];
+
     /** @var callable|null Para injecao em testes */
     private $callable = null;
+
+    private ?array $gatesOverride = null; // teste: ['write'=>bool,'destructive'=>bool,...,'readonly'=>bool]
+    private const IMPERSONATION_COMMANDS = [
+        'AddTicketReply','CreateProject','AddProjectTask','StartTaskTimer',
+        'EndTaskTimer','AddProjectMessage','UpdateToDoItem',
+    ];
+    private static array $adminIdCache = [];
+    private $adminIdResolver = null; // teste: fn(string $username): ?int
 
     public function __construct(private readonly string $adminUser = 'admin') {}
 
     public function setCallable(callable $fn): void
     {
         $this->callable = $fn;
+    }
+
+    public function setGates(array $gates): void { $this->gatesOverride = $gates; }
+
+    public function setAdminIdResolver(callable $fn): void { $this->adminIdResolver = $fn; }
+
+    private function classOf(string $command): string
+    {
+        return self::COMMAND_CLASS[$command] ?? 'WRITE'; // fail-safe
+    }
+
+    private function gateEnabled(string $class): bool
+    {
+        if ($class === 'READ') return true;
+        if ($this->boolSetting('nt_mcp_readonly', false, 'readonly')) return false; // master switch
+        [$key, $default] = match ($class) {
+            'WRITE'       => ['nt_mcp_enable_write', true],   // WRITE habilitado por padrão
+            'DESTRUCTIVE' => ['nt_mcp_enable_destructive', false],
+            'FINANCIAL'   => ['nt_mcp_enable_financial', false],
+            'COST'        => ['nt_mcp_enable_cost', false],
+            'COMMS'       => ['nt_mcp_enable_comms', false],
+            default       => ['nt_mcp_enable_write', false],
+        };
+        return $this->boolSetting($key, $default, strtolower($class));
+    }
+
+    /** Lê config booleana com override de teste e default seguro. */
+    private function boolSetting(string $key, bool $default, string $overrideKey): bool
+    {
+        if ($this->gatesOverride !== null) {
+            return (bool) ($this->gatesOverride[$overrideKey] ?? $default);
+        }
+        try {
+            $v = \WHMCS\Config\Setting::getValue($key);
+            if ($v === null || $v === '') return $default;
+            return $v === '1' || $v === 1 || $v === true;
+        } catch (\Throwable $e) {
+            return $default;
+        }
+    }
+
+    private function assertModeAllows(string $command): void
+    {
+        $class = $this->classOf($command);
+        if (!$this->gateEnabled($class)) {
+            self::auditLog("MCP BLOCKED {$class} '{$command}' (gate disabled)", []);
+            throw new \RuntimeException(
+                "LocalApiClient: command '{$command}' is blocked (class {$class} disabled by config)."
+            );
+        }
+    }
+
+    private function clampImpersonation(string $command, array $params): array
+    {
+        if (!in_array($command, self::IMPERSONATION_COMMANDS, true)) return $params;
+
+        if ($command === 'AddTicketReply') {
+            $params['adminusername'] = $this->adminUser; // força o admin do token
+            unset($params['adminid']);
+            return $params;
+        }
+        // comandos baseados em adminid
+        $id = $this->resolveAdminId($this->adminUser);
+        if ($id === null) {
+            throw new \RuntimeException(
+                "LocalApiClient: cannot resolve admin id for '{$this->adminUser}'; refusing caller-supplied admin."
+            );
+        }
+        $params['adminid'] = $id;
+        unset($params['adminusername']);
+        return $params;
+    }
+
+    private function resolveAdminId(string $username): ?int
+    {
+        if (array_key_exists($username, self::$adminIdCache)) return self::$adminIdCache[$username];
+        if ($this->adminIdResolver !== null) {
+            $id = ($this->adminIdResolver)($username);
+            if ($id !== null) self::$adminIdCache[$username] = $id;
+            return $id;
+        }
+        try {
+            $row = \WHMCS\Database\Capsule::table('tbladmins')->where('username', $username)->first();
+            $id = $row ? (int) $row->id : null;
+            if ($id !== null) self::$adminIdCache[$username] = $id;
+            return $id;
+        } catch (\Throwable $e) {
+            error_log('NT MCP: resolveAdminId failed: ' . $e->getMessage());
+            return null;
+        }
     }
 
     public function call(string $command, array $params = []): array
@@ -151,6 +287,9 @@ class LocalApiClient
                 "LocalApiClient: WHMCS API command '{$command}' is not in the allowed list."
             );
         }
+
+        $this->assertModeAllows($command);                       // A
+        $params = $this->clampImpersonation($command, $params);  // B
 
         // ---------------------------------------------------------------
         // SECURITY FIX (F8 -- HIGH): Audit logging for every tool
@@ -188,6 +327,8 @@ class LocalApiClient
                 $params
             );
         }
+
+        \NtMcp\Whmcs\ResponseRedactor::scrubSensitive($result);  // D defense-in-depth
 
         return $result;
     }

--- a/modules/addons/nt_mcp/src/Whmcs/ResponseRedactor.php
+++ b/modules/addons/nt_mcp/src/Whmcs/ResponseRedactor.php
@@ -41,11 +41,15 @@ final class ResponseRedactor
     }
 
     /**
-     * Pay methods: ALLOWLIST de campos seguros (substitui o denylist frágil que
-     * só removia 3 campos e vazava last-four/validade/ACH).
+     * Pay methods: ALLOWLIST alinhada ao payload real de GetPayMethods (WHMCS).
+     * Qualquer campo fora desta lista é descartado — inclui remote_token,
+     * card_number, cvv e tokens de gateway, que nunca são devolvidos.
+     * card_last_four já é mascarado pelo próprio WHMCS (só 4 dígitos).
      */
     private const PAYMETHOD_SAFE_KEYS = [
-        'id', 'payment_method_type', 'description', 'is_default', 'created_at', 'updated_at',
+        'id', 'type', 'description', 'gateway_name',
+        'contact_type', 'contact_id', 'card_last_four', 'expiry_date',
+        'start_date', 'issue_number', 'card_type', 'last_updated',
     ];
     public static function stripPayMethods(array &$result): void
     {
@@ -56,8 +60,6 @@ final class ResponseRedactor
             foreach (self::PAYMETHOD_SAFE_KEYS as $k) {
                 if (array_key_exists($k, $pm)) $safe[$k] = $pm[$k];
             }
-            // último dígito mascarado, se existir de forma explícita
-            if (isset($pm['card_last_four'])) $safe['card_last_four'] = $pm['card_last_four'];
             $pm = $safe;
         }
         unset($pm);

--- a/modules/addons/nt_mcp/src/Whmcs/ResponseRedactor.php
+++ b/modules/addons/nt_mcp/src/Whmcs/ResponseRedactor.php
@@ -1,0 +1,65 @@
+<?php
+namespace NtMcp\Whmcs;
+
+/** Redação central de respostas de tools antes de devolver ao chamador MCP. */
+final class ResponseRedactor
+{
+    /** Chaves nunca legítimas numa resposta — removidas em qualquer profundidade. */
+    private const ALWAYS_STRIP = ['password', 'password2', 'securityqans'];
+
+    /** Remove recursivamente chaves sensíveis (defense-in-depth). */
+    public static function scrubSensitive(array &$data, int $depth = 0): void
+    {
+        if ($depth > 8) return;
+        foreach ($data as $key => &$value) {
+            if (in_array(strtolower((string) $key), self::ALWAYS_STRIP, true)) {
+                unset($data[$key]);
+                continue;
+            }
+            if (is_array($value)) {
+                self::scrubSensitive($value, $depth + 1);
+            }
+        }
+        unset($value);
+    }
+
+    /** Remove password (hash do cliente) e securityqans de GetClientsDetails. */
+    public static function stripClientDetails(array &$result): void
+    {
+        self::scrubSensitive($result);
+    }
+
+    /** Remove password de products[].product[] (substitui os dois strip duplicados). */
+    public static function stripProductPasswords(array &$result): void
+    {
+        if (isset($result['products']['product']) && is_array($result['products']['product'])) {
+            foreach ($result['products']['product'] as &$p) {
+                unset($p['password']);
+            }
+            unset($p);
+        }
+    }
+
+    /**
+     * Pay methods: ALLOWLIST de campos seguros (substitui o denylist frágil que
+     * só removia 3 campos e vazava last-four/validade/ACH).
+     */
+    private const PAYMETHOD_SAFE_KEYS = [
+        'id', 'payment_method_type', 'description', 'is_default', 'created_at', 'updated_at',
+    ];
+    public static function stripPayMethods(array &$result): void
+    {
+        if (!isset($result['paymethods']) || !is_array($result['paymethods'])) return;
+        foreach ($result['paymethods'] as &$pm) {
+            if (!is_array($pm)) continue;
+            $safe = [];
+            foreach (self::PAYMETHOD_SAFE_KEYS as $k) {
+                if (array_key_exists($k, $pm)) $safe[$k] = $pm[$k];
+            }
+            // último dígito mascarado, se existir de forma explícita
+            if (isset($pm['card_last_four'])) $safe['card_last_four'] = $pm['card_last_four'];
+            $pm = $safe;
+        }
+        unset($pm);
+    }
+}

--- a/modules/addons/nt_mcp/tests/Auth/BearerAuthOAuthTest.php
+++ b/modules/addons/nt_mcp/tests/Auth/BearerAuthOAuthTest.php
@@ -46,8 +46,12 @@ class BearerAuthOAuthTest extends TestCase
         $this->assertSame('john', $auth->authenticate());
     }
 
-    public function test_valid_oauth_token_falls_back_to_admin_when_admin_user_empty(): void
+    public function test_valid_oauth_token_denies_when_admin_user_empty_and_no_fallback_configured(): void
     {
+        // SECURITY FIX (WO-7): empty admin_user on the token row falls
+        // through to getFallbackAdmin(), which now fails closed (null)
+        // instead of returning the hardcoded 'admin' superadmin when
+        // nt_mcp_admin_user isn't configured.
         $auth = $this->makeAuth();
         $row = (object) ['admin_user' => '   ', 'expires_at' => time() + 3600];
         $auth->setOAuthLookupCallable(fn(string $hash) => $row);
@@ -55,11 +59,13 @@ class BearerAuthOAuthTest extends TestCase
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . self::OAUTH_TOKEN;
 
         $result = $auth->authenticate();
-        $this->assertSame('admin', $result);
+        $this->assertNull($result);
     }
 
-    public function test_valid_oauth_token_without_admin_user_property_uses_fallback(): void
+    public function test_valid_oauth_token_without_admin_user_property_denies_without_fallback_configured(): void
     {
+        // SECURITY FIX (WO-7): same as above, but for a row that never had
+        // the admin_user column at all (pre-migration DBs).
         $auth = $this->makeAuth();
         $row = (object) ['expires_at' => time() + 3600]; // sem admin_user
         $auth->setOAuthLookupCallable(fn(string $hash) => $row);
@@ -67,7 +73,7 @@ class BearerAuthOAuthTest extends TestCase
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . self::OAUTH_TOKEN;
 
         $result = $auth->authenticate();
-        $this->assertSame('admin', $result);
+        $this->assertNull($result);
     }
 
     // --- Caminho de rejeicao ---
@@ -107,9 +113,13 @@ class BearerAuthOAuthTest extends TestCase
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $staticToken;
 
-        // Deve retornar o admin do token estatico (nao 'oauth_admin')
-        // getStaticTokenAdmin() -> getFallbackAdmin() -> 'admin' (WHMCS\Config\Setting nao disponivel em tests)
+        // Deve seguir o caminho do token estatico (nao 'oauth_admin'), que
+        // cai em getStaticTokenAdmin() -> getFallbackAdmin(). Sem
+        // nt_mcp_admin_user configurado (WHMCS\Config\Setting nao existe em
+        // testes), o fallback agora nega (null) em vez do antigo 'admin'
+        // hardcoded (SECURITY FIX WO-7) -- mas o importante e que NUNCA
+        // retorna 'oauth_admin'.
         $result = $auth->authenticate();
-        $this->assertSame('admin', $result);
+        $this->assertNull($result);
     }
 }

--- a/modules/addons/nt_mcp/tests/Auth/BearerAuthTest.php
+++ b/modules/addons/nt_mcp/tests/Auth/BearerAuthTest.php
@@ -20,11 +20,15 @@ class BearerAuthTest extends TestCase
 
     // --- isValid() backward compat tests ---
 
-    public function test_validates_correct_token(): void
+    public function test_correct_token_without_admin_configured_is_invalid(): void
     {
+        // SECURITY FIX (WO-7): a correct token is no longer sufficient on its
+        // own. Without nt_mcp_admin_user / nt_mcp_bearer_token_admin
+        // configured, the fallback fails closed (null) instead of binding to
+        // the hardcoded 'admin' superadmin, so isValid() must be false.
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . self::TOKEN;
         $auth = new BearerAuth($this->tokenHash);
-        $this->assertTrue($auth->isValid());
+        $this->assertFalse($auth->isValid());
     }
 
     public function test_rejects_wrong_token(): void
@@ -73,14 +77,17 @@ class BearerAuthTest extends TestCase
 
     // --- authenticate() tests ---
 
-    public function test_authenticate_returns_string_for_valid_static_token(): void
+    public function test_authenticate_returns_null_for_valid_static_token_without_admin_configured(): void
     {
+        // SECURITY FIX (WO-7): without nt_mcp_admin_user (and no
+        // nt_mcp_bearer_token_admin) configured, authenticate() must fail
+        // closed and return null instead of the old hardcoded 'admin'
+        // fallback -- a valid static token alone is no longer enough to
+        // bind to the superadmin account.
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . self::TOKEN;
         $auth = new BearerAuth($this->tokenHash);
         $result = $auth->authenticate();
-        $this->assertIsString($result);
-        // Without WHMCS config, falls back to 'admin'
-        $this->assertSame('admin', $result);
+        $this->assertNull($result);
     }
 
     public function test_authenticate_returns_null_for_invalid_token(): void

--- a/modules/addons/nt_mcp/tests/Http/CorsHandlerTest.php
+++ b/modules/addons/nt_mcp/tests/Http/CorsHandlerTest.php
@@ -79,4 +79,47 @@ class CorsHandlerTest extends TestCase
         $origins = CorsHandler::getAllowedOrigins();
         $this->assertSame([], $origins); // WHMCS not available → returns []
     }
+
+    // --- getAllowedOriginsOrFail() fail-closed (WO-5 / item E) ---
+
+    public function test_get_allowed_origins_or_fail_returns_false_on_config_error(): void
+    {
+        // No WHMCS bootstrap in tests → \WHMCS\Config\Setting doesn't exist → this is
+        // exactly the "real config-read error" path. It must return the `false`
+        // sentinel, NOT an empty array — an empty array would be indistinguishable
+        // from "no allowlist configured" and resolveOriginHeader() would then hand
+        // back a wildcard on what is actually an infra failure.
+        $result = CorsHandler::getAllowedOriginsOrFail();
+        $this->assertFalse($result);
+    }
+
+    public function test_get_allowed_origins_or_fail_error_would_not_resolve_to_wildcard_if_handled_correctly(): void
+    {
+        // Demonstrates the bug WO-5 fixes: naively feeding a config-read error into
+        // resolveOriginHeader() (by collapsing it to []) silently produces '*'.
+        $orFail = CorsHandler::getAllowedOriginsOrFail();
+        $this->assertFalse($orFail, 'error must be reported as false, not []');
+
+        // The buggy pre-fix behaviour (error treated as empty allowlist):
+        $wronglyCollapsed = $orFail === false ? [] : $orFail;
+        $this->assertSame('*', CorsHandler::resolveOriginHeader('https://evil.com', $wronglyCollapsed));
+
+        // handle() must check for the `false` sentinel explicitly (503) instead of
+        // ever calling resolveOriginHeader() with a collapsed empty array on error.
+    }
+
+    public function test_get_allowed_origins_still_collapses_error_to_empty_array_for_back_compat(): void
+    {
+        // getAllowedOrigins() (unlike getAllowedOriginsOrFail()) is a back-compat
+        // wrapper — existing non-handle() callers keep seeing [] on error.
+        $this->assertSame([], CorsHandler::getAllowedOrigins());
+    }
+
+    // --- allowlist configured + origin outside it → header omitted (reinforced) ---
+
+    public function test_configured_allowlist_with_origin_outside_it_omits_header(): void
+    {
+        $result = CorsHandler::resolveOriginHeader('https://not-allowed.example', ['https://claude.ai', 'https://app.example.com']);
+        $this->assertNull($result);
+    }
 }

--- a/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
+++ b/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
@@ -117,6 +117,17 @@ class IpResolverTest extends TestCase
         $this->assertSame('127.0.0.1', IpResolver::resolve());
     }
 
+    public function test_resolve_stops_at_first_untrusted_hop_and_ignores_forged_left(): void
+    {
+        // XFF: forged-client, untrusted private hop, trusted proxy (loopback).
+        // The untrusted private hop terminates the chain of trust — the forged
+        // leftmost value must NOT be returned; fall back to REMOTE_ADDR.
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4, 10.0.0.9, 127.0.0.1';
+
+        $this->assertSame('127.0.0.1', IpResolver::resolve());
+    }
+
     // --- resolve(): WHMCS native path (WO-TP) ---
 
     public function test_resolve_prefers_native_ip_behind_trusted_proxy(): void

--- a/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
+++ b/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace NtMcp\Tests\Http;
 
 use NtMcp\Http\IpResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * SECURITY FIX (WO-4): isTrustedProxy() extraction + CIDR support + resolve()
- * XFF client-IP validation (FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE).
+ * SECURITY FIX (WO-4 + WO-TP): isTrustedProxy() extraction + CIDR support,
+ * resolve() XFF client-IP validation, and unification with the WHMCS native
+ * trusted-proxy resolution.
  *
- * NOTE: \WHMCS\Config\Setting does not exist in the unit test environment
- * (see tests/bootstrap.php), so nt_mcp_trusted_proxies always resolves to ''
- * here and only the hardcoded loopback entries (127.0.0.1, ::1) are trusted.
- * CIDR matching against a *configured* trusted-proxies entry (e.g. the
- * "10.0.0.0/8 matches 10.0.0.5" scenario from the spec) is therefore not
- * directly exercisable in this suite; the CIDR arithmetic itself is fully
- * covered by IpResolverCidrTest, and isTrustedProxy()'s use of it is a thin,
- * already-covered pass-through (str_contains($entry, '/') ? isInCidr(...) :
- * exact match) that this suite documents rather than duplicates.
+ * \WHMCS\Config\Setting / \App do not exist in the unit test environment, so
+ * the native paths are driven through the test hooks setNativeIpResolverForTests()
+ * and setConfigReaderForTests(); resetForTests() in setUp/tearDown keeps the
+ * static hooks and the per-request trusted-proxy cache from leaking between
+ * tests (the whole suite shares one PHP process). With no hooks configured the
+ * resolver behaves exactly as before (only loopback trusted, no native IP).
  */
 class IpResolverTest extends TestCase
 {
@@ -28,14 +27,22 @@ class IpResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->serverBackup = $_SERVER;
+        IpResolver::resetForTests();
     }
 
     protected function tearDown(): void
     {
         $_SERVER = $this->serverBackup;
+        IpResolver::resetForTests();
     }
 
-    // --- isTrustedProxy() ---
+    /** @param array<string,mixed> $map */
+    private function configReturning(array $map): callable
+    {
+        return fn(string $key) => $map[$key] ?? null;
+    }
+
+    // --- isTrustedProxy(): loopback + defaults ---
 
     public function test_isTrustedProxy_loopback_v4_is_true(): void
     {
@@ -54,12 +61,12 @@ class IpResolverTest extends TestCase
 
     public function test_isTrustedProxy_private_ip_without_config_is_false(): void
     {
-        // Without a configured nt_mcp_trusted_proxies entry, private IPs are
-        // NOT implicitly trusted — only loopback is.
+        // Without any configured trusted-proxies entry, private IPs are NOT
+        // implicitly trusted — only loopback is.
         $this->assertFalse(IpResolver::isTrustedProxy('10.0.0.5'));
     }
 
-    // --- resolve() ---
+    // --- resolve(): fallback algorithm (no native path) ---
 
     public function test_resolve_returns_remote_addr_when_not_a_trusted_proxy(): void
     {
@@ -95,8 +102,7 @@ class IpResolverTest extends TestCase
     public function test_resolve_ignores_private_xff_client_ip_and_falls_back_to_remote_addr(): void
     {
         // SECURITY FIX (WO-4): a private/reserved-range IP claimed as the
-        // client in X-Forwarded-For is never a legitimate public client —
-        // FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE rejects it.
+        // client in X-Forwarded-For is never a legitimate public client.
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.0.1';
 
@@ -109,5 +115,177 @@ class IpResolverTest extends TestCase
         $_SERVER['HTTP_X_FORWARDED_FOR'] = 'not-an-ip';
 
         $this->assertSame('127.0.0.1', IpResolver::resolve());
+    }
+
+    // --- resolve(): WHMCS native path (WO-TP) ---
+
+    public function test_resolve_prefers_native_ip_behind_trusted_proxy(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // loopback => trusted
+        IpResolver::setNativeIpResolverForTests(fn() => '203.0.113.9');
+
+        $this->assertSame('203.0.113.9', IpResolver::resolve());
+    }
+
+    public function test_resolve_accepts_native_ip_equal_to_remote_addr(): void
+    {
+        // No proxy in the path: native == REMOTE_ADDR, accepted even though
+        // REMOTE_ADDR is not a trusted proxy.
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        IpResolver::setNativeIpResolverForTests(fn() => '8.8.8.8');
+
+        $this->assertSame('8.8.8.8', IpResolver::resolve());
+    }
+
+    public function test_resolve_rejects_native_ip_on_untrusted_direct_connection(): void
+    {
+        // COHERENCE GUARD: a directly-connected (untrusted) client that manages
+        // to influence the native value into a different IP must NOT be honored.
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8'; // not a trusted proxy
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4';
+        IpResolver::setNativeIpResolverForTests(fn() => '10.0.0.5');
+
+        $this->assertSame('8.8.8.8', IpResolver::resolve());
+    }
+
+    public function test_resolve_accepts_private_native_ip_behind_trusted_proxy(): void
+    {
+        // Behind a trusted proxy the native path may legitimately return a
+        // private IP (own-infra clients via a load balancer).
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        IpResolver::setNativeIpResolverForTests(fn() => '10.1.2.3');
+
+        $this->assertSame('10.1.2.3', IpResolver::resolve());
+    }
+
+    #[DataProvider('invalidNativeValueProvider')]
+    public function test_resolve_falls_back_on_invalid_native_values(mixed $nativeValue): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+        IpResolver::setNativeIpResolverForTests(fn() => $nativeValue);
+
+        $this->assertSame('8.8.8.8', IpResolver::resolve());
+    }
+
+    public static function invalidNativeValueProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'zero ip'      => ['0.0.0.0'],
+            'not an ip'    => ['not-an-ip'],
+            'non-string'   => [42],
+            'null'         => [null],
+        ];
+    }
+
+    public function test_resolve_falls_back_when_native_resolver_throws(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+        IpResolver::setNativeIpResolverForTests(function () {
+            throw new \RuntimeException('boom');
+        });
+
+        $this->assertSame('8.8.8.8', IpResolver::resolve());
+    }
+
+    // --- isTrustedProxy(): native + addon list parsing (WO-TP) ---
+
+    public function test_native_trusted_proxies_json_strings_cidr(): void
+    {
+        // Finally exercises CIDR matching against a *configured* entry — the
+        // gap documented in the WO-4 round.
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => '["10.0.0.0/8"]',
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('10.0.0.5'));
+        $this->assertFalse(IpResolver::isTrustedProxy('11.0.0.5'));
+    }
+
+    public function test_native_trusted_proxies_json_objects(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => '[{"ip":"172.16.0.0/12","note":"lb"}]',
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('172.16.1.1'));
+    }
+
+    public function test_native_trusted_proxies_already_array(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => ['192.0.2.10'],
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('192.0.2.10'));
+    }
+
+    public function test_native_trusted_proxies_php_serialized(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => serialize(['192.0.2.0/24']),
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('192.0.2.7'));
+    }
+
+    public function test_native_trusted_proxies_plain_csv(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => "198.51.100.7, 203.0.113.0/24",
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('198.51.100.7'));
+        $this->assertTrue(IpResolver::isTrustedProxy('203.0.113.9'));
+    }
+
+    public function test_native_trusted_proxies_garbage_yields_loopback_only(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => 'not-json-not-ip',
+        ]));
+
+        $this->assertFalse(IpResolver::isTrustedProxy('10.0.0.5'));
+        $this->assertTrue(IpResolver::isTrustedProxy('127.0.0.1'));
+    }
+
+    public function test_invalid_entries_dropped_valid_kept(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'TrustedProxyIps' => '["999.999.1.1","10.0.0.0/8"]',
+        ]));
+
+        // Invalid entry is dropped; the valid CIDR still matches.
+        $this->assertTrue(IpResolver::isTrustedProxy('10.0.0.5'));
+        $this->assertFalse(IpResolver::isTrustedProxy('999.999.1.1'));
+    }
+
+    public function test_addon_and_native_lists_merge(): void
+    {
+        IpResolver::setConfigReaderForTests($this->configReturning([
+            'nt_mcp_trusted_proxies' => '198.51.100.7',
+            'TrustedProxyIps'        => '["10.0.0.0/8"]',
+        ]));
+
+        $this->assertTrue(IpResolver::isTrustedProxy('198.51.100.7')); // from addon list
+        $this->assertTrue(IpResolver::isTrustedProxy('10.0.0.5'));     // from native list
+    }
+
+    public function test_trusted_proxies_cached_per_request(): void
+    {
+        $calls = ['nt_mcp_trusted_proxies' => 0, 'TrustedProxyIps' => 0];
+        IpResolver::setConfigReaderForTests(function (string $key) use (&$calls) {
+            $calls[$key] = ($calls[$key] ?? 0) + 1;
+            return $key === 'TrustedProxyIps' ? '203.0.113.0/24' : null;
+        });
+
+        IpResolver::isTrustedProxy('203.0.113.5');
+        IpResolver::isTrustedProxy('203.0.113.9');
+
+        // The merged list is parsed once per request; each key read exactly once.
+        $this->assertSame(1, $calls['TrustedProxyIps']);
+        $this->assertSame(1, $calls['nt_mcp_trusted_proxies']);
     }
 }

--- a/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
+++ b/modules/addons/nt_mcp/tests/Http/IpResolverTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NtMcp\Tests\Http;
+
+use NtMcp\Http\IpResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SECURITY FIX (WO-4): isTrustedProxy() extraction + CIDR support + resolve()
+ * XFF client-IP validation (FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE).
+ *
+ * NOTE: \WHMCS\Config\Setting does not exist in the unit test environment
+ * (see tests/bootstrap.php), so nt_mcp_trusted_proxies always resolves to ''
+ * here and only the hardcoded loopback entries (127.0.0.1, ::1) are trusted.
+ * CIDR matching against a *configured* trusted-proxies entry (e.g. the
+ * "10.0.0.0/8 matches 10.0.0.5" scenario from the spec) is therefore not
+ * directly exercisable in this suite; the CIDR arithmetic itself is fully
+ * covered by IpResolverCidrTest, and isTrustedProxy()'s use of it is a thin,
+ * already-covered pass-through (str_contains($entry, '/') ? isInCidr(...) :
+ * exact match) that this suite documents rather than duplicates.
+ */
+class IpResolverTest extends TestCase
+{
+    private ?array $serverBackup = null;
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+    }
+
+    // --- isTrustedProxy() ---
+
+    public function test_isTrustedProxy_loopback_v4_is_true(): void
+    {
+        $this->assertTrue(IpResolver::isTrustedProxy('127.0.0.1'));
+    }
+
+    public function test_isTrustedProxy_loopback_v6_is_true(): void
+    {
+        $this->assertTrue(IpResolver::isTrustedProxy('::1'));
+    }
+
+    public function test_isTrustedProxy_arbitrary_public_ip_is_false(): void
+    {
+        $this->assertFalse(IpResolver::isTrustedProxy('8.8.8.8'));
+    }
+
+    public function test_isTrustedProxy_private_ip_without_config_is_false(): void
+    {
+        // Without a configured nt_mcp_trusted_proxies entry, private IPs are
+        // NOT implicitly trusted — only loopback is.
+        $this->assertFalse(IpResolver::isTrustedProxy('10.0.0.5'));
+    }
+
+    // --- resolve() ---
+
+    public function test_resolve_returns_remote_addr_when_not_a_trusted_proxy(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4';
+
+        $this->assertSame('8.8.8.8', IpResolver::resolve());
+    }
+
+    public function test_resolve_returns_remote_addr_when_no_xff(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+
+        $this->assertSame('127.0.0.1', IpResolver::resolve());
+    }
+
+    public function test_resolve_returns_empty_remote_addr_as_zero_ip(): void
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+
+        $this->assertSame('0.0.0.0', IpResolver::resolve());
+    }
+
+    public function test_resolve_picks_rightmost_untrusted_public_ip_from_xff(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '1.2.3.4, 127.0.0.1';
+
+        $this->assertSame('1.2.3.4', IpResolver::resolve());
+    }
+
+    public function test_resolve_ignores_private_xff_client_ip_and_falls_back_to_remote_addr(): void
+    {
+        // SECURITY FIX (WO-4): a private/reserved-range IP claimed as the
+        // client in X-Forwarded-For is never a legitimate public client —
+        // FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE rejects it.
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.0.1';
+
+        $this->assertSame('127.0.0.1', IpResolver::resolve());
+    }
+
+    public function test_resolve_ignores_malformed_xff_entry(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = 'not-an-ip';
+
+        $this->assertSame('127.0.0.1', IpResolver::resolve());
+    }
+}

--- a/modules/addons/nt_mcp/tests/Http/TlsEnforcerTest.php
+++ b/modules/addons/nt_mcp/tests/Http/TlsEnforcerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NtMcp\Tests\Http;
+
+use NtMcp\Http\TlsEnforcer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SECURITY FIX (WO-4): TlsEnforcer::enforce() calls http_response_code()/
+ * header()/exit, so it is not directly unit-testable. Its decision logic was
+ * extracted into two pure, side-effect-free static methods —
+ * isRequestSecure() and isHttpBypassAllowed() — which this suite exercises
+ * directly by manipulating $_SERVER / the NT_MCP_ALLOW_HTTP env var.
+ */
+class TlsEnforcerTest extends TestCase
+{
+    private ?array $serverBackup = null;
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+        putenv('NT_MCP_ALLOW_HTTP');
+        unset($_ENV['NT_MCP_ALLOW_HTTP']);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+        putenv('NT_MCP_ALLOW_HTTP');
+        unset($_ENV['NT_MCP_ALLOW_HTTP']);
+    }
+
+    // --- isRequestSecure() ---
+
+    public function test_isRequestSecure_true_when_https_server_var_on(): void
+    {
+        $_SERVER['HTTPS'] = 'on';
+        unset($_SERVER['SERVER_PORT'], $_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+        $this->assertTrue(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_false_when_https_server_var_is_off(): void
+    {
+        $_SERVER['HTTPS'] = 'off';
+        unset($_SERVER['SERVER_PORT'], $_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+        $this->assertFalse(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_true_when_server_port_443(): void
+    {
+        unset($_SERVER['HTTPS'], $_SERVER['HTTP_X_FORWARDED_PROTO']);
+        $_SERVER['SERVER_PORT'] = '443';
+
+        $this->assertTrue(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_true_when_xfp_https_from_trusted_proxy(): void
+    {
+        unset($_SERVER['HTTPS'], $_SERVER['SERVER_PORT']);
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+        $this->assertTrue(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_false_when_xfp_https_from_untrusted_remote_addr(): void
+    {
+        // SECURITY FIX (WO-4): X-Forwarded-Proto is attacker-controlled unless
+        // it comes through a trusted proxy — must not be honored otherwise.
+        unset($_SERVER['HTTPS'], $_SERVER['SERVER_PORT']);
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+        $this->assertFalse(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_false_when_no_https_signal_present(): void
+    {
+        unset($_SERVER['HTTPS'], $_SERVER['SERVER_PORT'], $_SERVER['HTTP_X_FORWARDED_PROTO']);
+
+        $this->assertFalse(TlsEnforcer::isRequestSecure());
+    }
+
+    // --- isHttpBypassAllowed() ---
+
+    public function test_isHttpBypassAllowed_false_when_env_not_set(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $this->assertFalse(TlsEnforcer::isHttpBypassAllowed());
+    }
+
+    public function test_isHttpBypassAllowed_true_when_env_set_and_remote_addr_is_trusted_proxy(): void
+    {
+        putenv('NT_MCP_ALLOW_HTTP=1');
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+        $this->assertTrue(TlsEnforcer::isHttpBypassAllowed());
+    }
+
+    public function test_isHttpBypassAllowed_true_when_env_set_and_remote_addr_is_private(): void
+    {
+        putenv('NT_MCP_ALLOW_HTTP=1');
+        $_SERVER['REMOTE_ADDR'] = '10.0.0.5';
+
+        $this->assertTrue(TlsEnforcer::isHttpBypassAllowed());
+    }
+
+    public function test_isHttpBypassAllowed_false_when_env_set_but_remote_addr_is_public(): void
+    {
+        // SECURITY FIX (WO-4): NT_MCP_ALLOW_HTTP must never let an arbitrary
+        // internet client bypass TLS enforcement.
+        putenv('NT_MCP_ALLOW_HTTP=1');
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+
+        $this->assertFalse(TlsEnforcer::isHttpBypassAllowed());
+    }
+
+    public function test_isHttpBypassAllowed_true_via_env_superglobal(): void
+    {
+        $_ENV['NT_MCP_ALLOW_HTTP'] = '1';
+        $_SERVER['REMOTE_ADDR'] = '::1';
+
+        $this->assertTrue(TlsEnforcer::isHttpBypassAllowed());
+    }
+}

--- a/modules/addons/nt_mcp/tests/Http/TlsEnforcerTest.php
+++ b/modules/addons/nt_mcp/tests/Http/TlsEnforcerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NtMcp\Tests\Http;
 
+use NtMcp\Http\IpResolver;
 use NtMcp\Http\TlsEnforcer;
 use PHPUnit\Framework\TestCase;
 
@@ -23,6 +24,7 @@ class TlsEnforcerTest extends TestCase
         $this->serverBackup = $_SERVER;
         putenv('NT_MCP_ALLOW_HTTP');
         unset($_ENV['NT_MCP_ALLOW_HTTP']);
+        IpResolver::resetForTests();
     }
 
     protected function tearDown(): void
@@ -30,6 +32,7 @@ class TlsEnforcerTest extends TestCase
         $_SERVER = $this->serverBackup;
         putenv('NT_MCP_ALLOW_HTTP');
         unset($_ENV['NT_MCP_ALLOW_HTTP']);
+        IpResolver::resetForTests();
     }
 
     // --- isRequestSecure() ---
@@ -83,6 +86,20 @@ class TlsEnforcerTest extends TestCase
         unset($_SERVER['HTTPS'], $_SERVER['SERVER_PORT'], $_SERVER['HTTP_X_FORWARDED_PROTO']);
 
         $this->assertFalse(TlsEnforcer::isRequestSecure());
+    }
+
+    public function test_isRequestSecure_true_when_xfp_https_from_native_trusted_proxy(): void
+    {
+        // WO-TP: a proxy configured ONLY in the WHMCS native list must also be
+        // honored for X-Forwarded-Proto — TlsEnforcer inherits the merged list.
+        unset($_SERVER['HTTPS'], $_SERVER['SERVER_PORT']);
+        IpResolver::setConfigReaderForTests(
+            fn(string $key) => $key === 'TrustedProxyIps' ? '["203.0.113.0/24"]' : null
+        );
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.7';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+        $this->assertTrue(TlsEnforcer::isRequestSecure());
     }
 
     // --- isHttpBypassAllowed() ---

--- a/modules/addons/nt_mcp/tests/Tools/BillingToolsTest.php
+++ b/modules/addons/nt_mcp/tests/Tools/BillingToolsTest.php
@@ -11,6 +11,10 @@ class BillingToolsTest extends TestCase
     private function makeTools(?callable $callable = null): BillingTools
     {
         $api = new LocalApiClient('testadmin');
+        // Financial gate is disabled by default (WO-2); enable it here so these
+        // tests can exercise BillingTools' param-building logic. The gate's
+        // default-deny behavior itself is covered by LocalApiClientGateTest.
+        $api->setGates(['financial' => true]);
         $api->setCallable($callable ?? function (string $cmd, array $params) {
             return ['result' => 'success', 'invoiceid' => 1];
         });
@@ -157,5 +161,53 @@ class BillingToolsTest extends TestCase
 
         $this->assertSame('2026-03-30', $capturedParams['date']);
         $this->assertTrue($capturedParams['noemail']);
+    }
+
+    public function test_get_pay_methods_strips_sensitive_fields(): void
+    {
+        $tools = $this->makeTools(function (string $cmd, array $params) {
+            return [
+                'result' => 'success',
+                'paymethods' => [
+                    [
+                        'id' => 1,
+                        'payment_method_type' => 'creditcard',
+                        'description' => 'Visa ending 1234',
+                        'is_default' => true,
+                        'card_number' => '4111111111111234',
+                        'expiry' => '12/30',
+                        'token' => 'tok_abc123',
+                        'gateway_customer_id' => 'cus_xyz789',
+                        'account_number' => '000123456',
+                        'routing_number' => '021000021',
+                    ],
+                ],
+            ];
+        });
+
+        $json = $tools->getPayMethods(1);
+        $data = json_decode($json, true);
+
+        $pm = $data['paymethods'][0];
+        $this->assertArrayNotHasKey('card_number', $pm);
+        $this->assertArrayNotHasKey('expiry', $pm);
+        $this->assertArrayNotHasKey('token', $pm);
+        $this->assertArrayNotHasKey('gateway_customer_id', $pm);
+        $this->assertArrayNotHasKey('account_number', $pm);
+        $this->assertArrayNotHasKey('routing_number', $pm);
+        $this->assertSame(1, $pm['id']);
+        $this->assertSame('creditcard', $pm['payment_method_type']);
+    }
+
+    public function test_get_pay_methods_no_paymethods_field_does_not_error(): void
+    {
+        $tools = $this->makeTools(function (string $cmd, array $params) {
+            return ['result' => 'success'];
+        });
+
+        $json = $tools->getPayMethods(1);
+        $data = json_decode($json, true);
+
+        $this->assertSame('success', $data['result']);
     }
 }

--- a/modules/addons/nt_mcp/tests/Tools/BillingToolsTest.php
+++ b/modules/addons/nt_mcp/tests/Tools/BillingToolsTest.php
@@ -171,11 +171,12 @@ class BillingToolsTest extends TestCase
                 'paymethods' => [
                     [
                         'id' => 1,
-                        'payment_method_type' => 'creditcard',
+                        'type' => 'RemoteCreditCard',
                         'description' => 'Visa ending 1234',
-                        'is_default' => true,
+                        'card_last_four' => '1234',
+                        'expiry_date' => '12/30',
                         'card_number' => '4111111111111234',
-                        'expiry' => '12/30',
+                        'remote_token' => '{"customer":"cus_xyz"}',
                         'token' => 'tok_abc123',
                         'gateway_customer_id' => 'cus_xyz789',
                         'account_number' => '000123456',
@@ -190,13 +191,15 @@ class BillingToolsTest extends TestCase
 
         $pm = $data['paymethods'][0];
         $this->assertArrayNotHasKey('card_number', $pm);
-        $this->assertArrayNotHasKey('expiry', $pm);
+        $this->assertArrayNotHasKey('remote_token', $pm);
         $this->assertArrayNotHasKey('token', $pm);
         $this->assertArrayNotHasKey('gateway_customer_id', $pm);
         $this->assertArrayNotHasKey('account_number', $pm);
         $this->assertArrayNotHasKey('routing_number', $pm);
         $this->assertSame(1, $pm['id']);
-        $this->assertSame('creditcard', $pm['payment_method_type']);
+        $this->assertSame('RemoteCreditCard', $pm['type']);
+        $this->assertSame('1234', $pm['card_last_four']);
+        $this->assertSame('12/30', $pm['expiry_date']);
     }
 
     public function test_get_pay_methods_no_paymethods_field_does_not_error(): void

--- a/modules/addons/nt_mcp/tests/Tools/ClientToolsTest.php
+++ b/modules/addons/nt_mcp/tests/Tools/ClientToolsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NtMcp\Tests\Tools;
+
+use NtMcp\Tools\ClientTools;
+use NtMcp\Whmcs\LocalApiClient;
+use PHPUnit\Framework\TestCase;
+
+class ClientToolsTest extends TestCase
+{
+    private function makeTools(?callable $callable = null): ClientTools
+    {
+        $api = new LocalApiClient('testadmin');
+        $api->setCallable($callable ?? function (string $cmd, array $params) {
+            return ['result' => 'success'];
+        });
+        return new ClientTools($api);
+    }
+
+    public function test_get_client_strips_password_and_securityqans(): void
+    {
+        $tools = $this->makeTools(function (string $cmd, array $params) {
+            return [
+                'result' => 'success',
+                'clientid' => 1,
+                'firstname' => 'John',
+                'password' => 'hash-of-secret',
+                'securityqans' => 'my-answer',
+            ];
+        });
+
+        $json = $tools->getClient(1);
+        $data = json_decode($json, true);
+
+        $this->assertArrayNotHasKey('password', $data);
+        $this->assertArrayNotHasKey('securityqans', $data);
+        $this->assertSame('John', $data['firstname']);
+    }
+
+    public function test_get_client_no_password_field_survives_intact(): void
+    {
+        $tools = $this->makeTools(function (string $cmd, array $params) {
+            return ['result' => 'success', 'clientid' => 1, 'firstname' => 'Jane'];
+        });
+
+        $json = $tools->getClient(1);
+        $data = json_decode($json, true);
+
+        $this->assertSame('Jane', $data['firstname']);
+    }
+
+    public function test_get_client_sends_clientid_and_stats(): void
+    {
+        $capturedParams = null;
+        $tools = $this->makeTools(function (string $cmd, array $params) use (&$capturedParams) {
+            $capturedParams = ['cmd' => $cmd, 'params' => $params];
+            return ['result' => 'success'];
+        });
+
+        $tools->getClient(7);
+
+        $this->assertSame('GetClientsDetails', $capturedParams['cmd']);
+        $this->assertSame(7, $capturedParams['params']['clientid']);
+        $this->assertTrue($capturedParams['params']['stats']);
+    }
+
+    public function test_get_client_products_strips_password_from_products(): void
+    {
+        $tools = $this->makeTools(function (string $cmd, array $params) {
+            return [
+                'result' => 'success',
+                'products' => [
+                    'product' => [
+                        ['id' => 1, 'name' => 'Hosting', 'password' => 's3cr3t'],
+                    ],
+                ],
+            ];
+        });
+
+        $json = $tools->getClientProducts(1);
+        $data = json_decode($json, true);
+
+        $this->assertArrayNotHasKey('password', $data['products']['product'][0]);
+        $this->assertSame('Hosting', $data['products']['product'][0]['name']);
+    }
+}

--- a/modules/addons/nt_mcp/tests/Tools/TicketToolsTest.php
+++ b/modules/addons/nt_mcp/tests/Tools/TicketToolsTest.php
@@ -32,8 +32,11 @@ class TicketToolsTest extends TestCase
         $this->assertArrayNotHasKey('adminid', $capturedParams);
     }
 
-    public function test_reply_ticket_sends_adminusername(): void
+    public function test_reply_ticket_clamps_adminusername_to_token_admin(): void
     {
+        // WO-2 anti-impersonation clamp: LocalApiClient forces adminusername to the
+        // admin bound to the current token, regardless of what the caller supplies,
+        // to prevent a caller from forging replies as an arbitrary admin.
         $capturedParams = null;
         $tools = $this->makeTools(function (string $cmd, array $params) use (&$capturedParams) {
             $capturedParams = $params;
@@ -42,7 +45,7 @@ class TicketToolsTest extends TestCase
 
         $tools->replyTicket(10, 'Hello', adminusername: 'admin1');
 
-        $this->assertSame('admin1', $capturedParams['adminusername']);
+        $this->assertSame('testadmin', $capturedParams['adminusername']);
     }
 
     public function test_reply_ticket_sends_noemail_when_true(): void
@@ -68,7 +71,12 @@ class TicketToolsTest extends TestCase
 
         $tools->replyTicket(10, 'Hello');
 
-        $this->assertSame(['ticketid' => 10, 'message' => 'Hello'], $capturedParams);
+        // adminusername is always injected by LocalApiClient's anti-impersonation
+        // clamp (WO-2) for AddTicketReply, even when the caller supplies none.
+        $this->assertSame(
+            ['ticketid' => 10, 'message' => 'Hello', 'adminusername' => 'testadmin'],
+            $capturedParams
+        );
     }
 
     public function test_open_ticket_without_clientid_uses_name_email(): void

--- a/modules/addons/nt_mcp/tests/Whmcs/CapsuleClientAllowlistTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/CapsuleClientAllowlistTest.php
@@ -12,6 +12,9 @@ class CapsuleClientAllowlistTest extends TestCase
     protected function setUp(): void
     {
         $this->client = new CapsuleClient();
+        // Bypass the write gate so the allowlist-rejection tests reach the
+        // table/column checks. The gate itself is tested separately below.
+        $this->client->setWritableForTests(true);
     }
 
     public function test_select_rejects_disallowed_table(): void
@@ -74,5 +77,25 @@ class CapsuleClientAllowlistTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('not permitted');
         $this->client->delete('tbladmins', ['id' => 1]);
+    }
+
+    // ---------------------------------------------------------------
+    // Write gate (read-only / nt_mcp_enable_write)
+    // ---------------------------------------------------------------
+
+    public function test_insert_blocked_when_write_gate_disabled(): void
+    {
+        $this->client->setWritableForTests(false);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('writes disabled');
+        $this->client->insert('mod_mgcrm_contacts', ['name' => 'x']);
+    }
+
+    public function test_delete_blocked_when_write_gate_disabled(): void
+    {
+        $this->client->setWritableForTests(false);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('writes disabled');
+        $this->client->delete('mod_mgcrm_contacts', ['id' => 1]);
     }
 }

--- a/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
@@ -111,6 +111,23 @@ class LocalApiClientGateTest extends TestCase
         $this->assertArrayNotHasKey('adminusername', $captured);
     }
 
+    public function test_update_project_clamps_adminid_via_resolver(): void
+    {
+        // UpdateProject/UpdateProjectTask also accept a caller-supplied adminid
+        // and must be clamped to the token-bound admin.
+        $client = new LocalApiClient('testadmin');
+        $client->setAdminIdResolver(fn(string $username) => 42);
+        $captured = null;
+        $client->setCallable(function (string $cmd, array $params) use (&$captured) {
+            $captured = $params;
+            return ['result' => 'success'];
+        });
+
+        $client->call('UpdateProject', ['projectid' => 5, 'adminid' => 999]);
+
+        $this->assertSame(42, $captured['adminid']);
+    }
+
     // ---------------------------------------------------------------
     // D-server) Scrub de resposta
     // ---------------------------------------------------------------

--- a/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
@@ -1,0 +1,132 @@
+<?php
+// tests/Whmcs/LocalApiClientGateTest.php
+namespace NtMcp\Tests\Whmcs;
+
+use NtMcp\Whmcs\LocalApiClient;
+use PHPUnit\Framework\TestCase;
+
+class LocalApiClientGateTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // A) Gate de classe
+    // ---------------------------------------------------------------
+
+    public function test_read_command_always_passes_regardless_of_gates(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setGates(['write' => false, 'destructive' => false, 'financial' => false, 'readonly' => true]);
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $result = $client->call('GetClients', []);
+
+        $this->assertSame('success', $result['result']);
+    }
+
+    public function test_module_terminate_blocked_when_destructive_gate_off(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setGates(['destructive' => false]);
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('blocked');
+        $client->call('ModuleTerminate', ['serviceid' => 1]);
+    }
+
+    public function test_module_terminate_allowed_when_destructive_gate_on(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setGates(['destructive' => true]);
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $result = $client->call('ModuleTerminate', ['serviceid' => 1]);
+
+        $this->assertSame('success', $result['result']);
+    }
+
+    public function test_add_credit_blocked_by_default_financial_gate(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setGates([]); // financial off by default
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('blocked');
+        $client->call('AddCredit', ['clientid' => 1, 'amount' => 10]);
+    }
+
+    public function test_add_client_write_allowed_by_default(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $result = $client->call('AddClient', ['firstname' => 'a']);
+
+        $this->assertSame('success', $result['result']);
+    }
+
+    public function test_add_client_blocked_by_readonly_master_switch(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setGates(['readonly' => true]);
+        $client->setCallable(fn() => ['result' => 'success']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('blocked');
+        $client->call('AddClient', ['firstname' => 'a']);
+    }
+
+    // ---------------------------------------------------------------
+    // B) Clamp de impersonacao
+    // ---------------------------------------------------------------
+
+    public function test_add_ticket_reply_clamps_adminusername_to_token_admin(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $captured = null;
+        $client->setCallable(function (string $cmd, array $params) use (&$captured) {
+            $captured = $params;
+            return ['result' => 'success'];
+        });
+
+        $client->call('AddTicketReply', ['ticketid' => 1, 'adminusername' => 'ghost']);
+
+        $this->assertSame('testadmin', $captured['adminusername']);
+        $this->assertArrayNotHasKey('adminid', $captured);
+    }
+
+    public function test_create_project_clamps_adminid_via_resolver(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setAdminIdResolver(fn(string $username) => 7);
+        $captured = null;
+        $client->setCallable(function (string $cmd, array $params) use (&$captured) {
+            $captured = $params;
+            return ['result' => 'success'];
+        });
+
+        $client->call('CreateProject', ['name' => 'Project X', 'adminid' => 999]);
+
+        $this->assertSame(7, $captured['adminid']);
+        $this->assertArrayNotHasKey('adminusername', $captured);
+    }
+
+    // ---------------------------------------------------------------
+    // D-server) Scrub de resposta
+    // ---------------------------------------------------------------
+
+    public function test_call_scrubs_sensitive_keys_from_response(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setCallable(fn() => [
+            'result' => 'success',
+            'password' => 'x',
+            'a' => ['securityqans' => 'y'],
+        ]);
+
+        $result = $client->call('GetClients', []);
+
+        $this->assertArrayNotHasKey('password', $result);
+        $this->assertArrayNotHasKey('securityqans', $result['a']);
+    }
+}

--- a/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/LocalApiClientGateTest.php
@@ -126,6 +126,23 @@ class LocalApiClientGateTest extends TestCase
         $client->call('UpdateProject', ['projectid' => 5, 'adminid' => 999]);
 
         $this->assertSame(42, $captured['adminid']);
+        $this->assertArrayNotHasKey('adminusername', $captured);
+    }
+
+    public function test_update_project_task_clamps_adminid_via_resolver(): void
+    {
+        $client = new LocalApiClient('testadmin');
+        $client->setAdminIdResolver(fn(string $username) => 42);
+        $captured = null;
+        $client->setCallable(function (string $cmd, array $params) use (&$captured) {
+            $captured = $params;
+            return ['result' => 'success'];
+        });
+
+        $client->call('UpdateProjectTask', ['taskid' => 5, 'adminid' => 999]);
+
+        $this->assertSame(42, $captured['adminid']);
+        $this->assertArrayNotHasKey('adminusername', $captured);
     }
 
     // ---------------------------------------------------------------

--- a/modules/addons/nt_mcp/tests/Whmcs/ResponseRedactorTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/ResponseRedactorTest.php
@@ -1,0 +1,112 @@
+<?php
+// tests/Whmcs/ResponseRedactorTest.php
+namespace NtMcp\Tests\Whmcs;
+
+use NtMcp\Whmcs\ResponseRedactor;
+use PHPUnit\Framework\TestCase;
+
+class ResponseRedactorTest extends TestCase
+{
+    public function test_scrub_sensitive_removes_nested_password(): void
+    {
+        $data = [
+            'result' => 'success',
+            'client' => [
+                'firstname' => 'Jane',
+                'password' => 'hash-should-not-leak',
+                'nested' => [
+                    'securityqans' => 'my-answer',
+                    'deeper' => [
+                        'password2' => 'still-here',
+                        'ok' => 'keep-me',
+                    ],
+                ],
+            ],
+        ];
+
+        ResponseRedactor::scrubSensitive($data);
+
+        $this->assertArrayNotHasKey('password', $data['client']);
+        $this->assertArrayNotHasKey('securityqans', $data['client']['nested']);
+        $this->assertArrayNotHasKey('password2', $data['client']['nested']['deeper']);
+        $this->assertSame('keep-me', $data['client']['nested']['deeper']['ok']);
+        $this->assertSame('Jane', $data['client']['firstname']);
+    }
+
+    public function test_strip_pay_methods_keeps_only_allowlisted_keys(): void
+    {
+        $result = [
+            'paymethods' => [
+                [
+                    'id' => 1,
+                    'payment_method_type' => 'creditcard',
+                    'description' => 'Visa ending in 1234',
+                    'is_default' => true,
+                    'created_at' => '2026-01-01',
+                    'updated_at' => '2026-02-01',
+                    'card_number' => '4111111111111111',
+                    'expiry' => '12/30',
+                    'account_number' => '000123456',
+                    'routing_number' => '021000021',
+                    'token' => 'tok_secret',
+                    'gateway_customer_id' => 'cus_secret',
+                ],
+            ],
+        ];
+
+        ResponseRedactor::stripPayMethods($result);
+
+        $pm = $result['paymethods'][0];
+
+        $this->assertArrayNotHasKey('card_number', $pm);
+        $this->assertArrayNotHasKey('expiry', $pm);
+        $this->assertArrayNotHasKey('account_number', $pm);
+        $this->assertArrayNotHasKey('routing_number', $pm);
+        $this->assertArrayNotHasKey('token', $pm);
+        $this->assertArrayNotHasKey('gateway_customer_id', $pm);
+
+        $this->assertSame(1, $pm['id']);
+        $this->assertSame('creditcard', $pm['payment_method_type']);
+        $this->assertSame('Visa ending in 1234', $pm['description']);
+        $this->assertTrue($pm['is_default']);
+        $this->assertSame('2026-01-01', $pm['created_at']);
+        $this->assertSame('2026-02-01', $pm['updated_at']);
+    }
+
+    public function test_strip_pay_methods_keeps_card_last_four_when_present(): void
+    {
+        $result = [
+            'paymethods' => [
+                [
+                    'id' => 2,
+                    'card_number' => '4111111111111111',
+                    'card_last_four' => '1111',
+                ],
+            ],
+        ];
+
+        ResponseRedactor::stripPayMethods($result);
+
+        $pm = $result['paymethods'][0];
+
+        $this->assertArrayNotHasKey('card_number', $pm);
+        $this->assertSame('1111', $pm['card_last_four']);
+    }
+
+    public function test_strip_client_details_removes_password_and_securityqans(): void
+    {
+        $result = [
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'password' => 'hashed-password',
+            'securityqans' => 'answer',
+        ];
+
+        ResponseRedactor::stripClientDetails($result);
+
+        $this->assertArrayNotHasKey('password', $result);
+        $this->assertArrayNotHasKey('securityqans', $result);
+        $this->assertSame('John', $result['firstname']);
+        $this->assertSame('Doe', $result['lastname']);
+    }
+}

--- a/modules/addons/nt_mcp/tests/Whmcs/ResponseRedactorTest.php
+++ b/modules/addons/nt_mcp/tests/Whmcs/ResponseRedactorTest.php
@@ -35,21 +35,27 @@ class ResponseRedactorTest extends TestCase
 
     public function test_strip_pay_methods_keeps_only_allowlisted_keys(): void
     {
+        // Payload shaped like the real WHMCS GetPayMethods response.
         $result = [
             'paymethods' => [
                 [
                     'id' => 1,
-                    'payment_method_type' => 'creditcard',
-                    'description' => 'Visa ending in 1234',
-                    'is_default' => true,
-                    'created_at' => '2026-01-01',
-                    'updated_at' => '2026-02-01',
+                    'type' => 'RemoteCreditCard',
+                    'description' => 'Default Card',
+                    'gateway_name' => 'stripe',
+                    'contact_type' => 'Client',
+                    'contact_id' => 1,
+                    'card_last_four' => '4242',
+                    'expiry_date' => '02/30',
+                    'card_type' => 'Visa',
+                    'last_updated' => '2026-05-17 10:01',
+                    // sensitive — must be dropped by the allowlist:
                     'card_number' => '4111111111111111',
-                    'expiry' => '12/30',
-                    'account_number' => '000123456',
-                    'routing_number' => '021000021',
+                    'remote_token' => '{"customer":"cus_x","method":"pm_x"}',
                     'token' => 'tok_secret',
                     'gateway_customer_id' => 'cus_secret',
+                    'account_number' => '000123456',
+                    'routing_number' => '021000021',
                 ],
             ],
         ];
@@ -58,19 +64,17 @@ class ResponseRedactorTest extends TestCase
 
         $pm = $result['paymethods'][0];
 
-        $this->assertArrayNotHasKey('card_number', $pm);
-        $this->assertArrayNotHasKey('expiry', $pm);
-        $this->assertArrayNotHasKey('account_number', $pm);
-        $this->assertArrayNotHasKey('routing_number', $pm);
-        $this->assertArrayNotHasKey('token', $pm);
-        $this->assertArrayNotHasKey('gateway_customer_id', $pm);
+        foreach (['card_number', 'remote_token', 'token', 'gateway_customer_id', 'account_number', 'routing_number'] as $secret) {
+            $this->assertArrayNotHasKey($secret, $pm);
+        }
 
         $this->assertSame(1, $pm['id']);
-        $this->assertSame('creditcard', $pm['payment_method_type']);
-        $this->assertSame('Visa ending in 1234', $pm['description']);
-        $this->assertTrue($pm['is_default']);
-        $this->assertSame('2026-01-01', $pm['created_at']);
-        $this->assertSame('2026-02-01', $pm['updated_at']);
+        $this->assertSame('RemoteCreditCard', $pm['type']);
+        $this->assertSame('Default Card', $pm['description']);
+        $this->assertSame('stripe', $pm['gateway_name']);
+        $this->assertSame('4242', $pm['card_last_four']);
+        $this->assertSame('02/30', $pm['expiry_date']);
+        $this->assertSame('Visa', $pm['card_type']);
     }
 
     public function test_strip_pay_methods_keeps_card_last_four_when_present(): void


### PR DESCRIPTION
## Contexto

Auditoria de segurança de produção do addon NT MCP antes de expor o endpoint MCP publicamente. A base de autenticação/criptografia é sólida (SHA-256 + `hash_equals`, PKCE S256, códigos/tokens hasheados com consumo atômico, allowlists estritas, CSRF HMAC). As falhas reais estavam em **autorização/blast radius**, **confiança indevida em headers de proxy** e **defaults fail-open**. Este PR aplica os fixes **P0** mantendo a postura escolhida: escrita permitida, mas **finanças e ações destrutivas bloqueadas por padrão**.

## Mudanças

### Blast radius / autorização
- **Gate central por classe de comando** (`LocalApiClient::call()`): mapa `COMMAND_CLASS` dos 83 comandos. `READ` sempre permitido, `WRITE` por padrão; `DESTRUCTIVE`, `FINANCIAL`, `COST`, `COMMS` **bloqueados por padrão** (opt-in `nt_mcp_enable_*`). Master switch `nt_mcp_readonly` (**fail-closed**). Espelhado em `CapsuleClient`.
- **Clamp de impersonação**: `AddTicketReply` e comandos de projeto/todo (inclui `UpdateProject`/`UpdateProjectTask`) forçam o admin do token, ignorando `adminid`/`adminusername` do chamador.
- **`AcceptQuote` reclassificado `WRITE → FINANCIAL`** — aceitar quote gera fatura/pedido, logo é bloqueado por padrão.

### Vazamento de PII
- Novo **`ResponseRedactor`** central. `getClient` deixa de vazar hash de senha e `securityqans`; `getPayMethods` usa **allowlist alinhada ao payload real do WHMCS** (não vaza número de cartão/`remote_token`/ACH). Scrub recursivo defense-in-depth.

### Confiança de transporte
- **`IpResolver`**: `isTrustedProxy()` com **CIDR**; o IP-cliente do `X-Forwarded-For` rejeita ranges privados/reservados.
- **Unificação com o WHMCS nativo (WO-TP)**: `resolve()` passa a preferir o IP que o próprio WHMCS resolve (`\App::getClientIp()` — honra a *Trusted Proxy List* + *Proxy IP Header* da aba **Security**), com **coherence guard** contra spoof em conexão direta; `isTrustedProxy()` mescla a lista nativa (`TrustedProxyIps`) ∪ `nt_mcp_trusted_proxies` (aditivo/opcional), com parse defensivo multi-formato e cache por request. Falha/indisponível → fallback XFF anterior. Elimina o drift em que o WHMCS logava um IP e a allowlist/rate-limit chaveava por outro.
- **`TlsEnforcer`**: `X-Forwarded-Proto: https` só é confiado de proxy confiável; `NT_MCP_ALLOW_HTTP` só de loopback/privado/proxy confiável e sempre logado.

### Fail-closed
- **`CorsHandler`**: erro de leitura de config responde 503, nunca degrada para `*`.
- **`BearerAuth`** e **`Server::run()`**: sem admin resolvível, **negam 401** — nunca vinculam ao superadmin `admin` hardcoded.

### Hardening
- **`oauth.php`**: ordem de `require` (vendor antes de `init.php`) + `IpAllowlist` + rate limit no entry.
- **`Server.php`**: leitura do corpo limitada a 1 MB (`file_get_contents` com maxlen + 413), além do header `Content-Length`.

## Testes

Suíte completa **verde: 179 testes, 276 assertions** (baseline 111). Cobrem gate por classe, clamp (incl. UpdateProject/UpdateProjectTask), scrub/redactor, transporte (XFF/CIDR/XFP), unificação de trusted-proxy (coherence guard, formatos de parse, mesclagem, cache) e herança pelo TlsEnforcer. Sem afrouxamento de código de produção.

## Config (aplicar no WHMCS antes de expor)

- `nt_mcp_allowed_ips` — allowlist de IP (**controle primário**)
- `nt_mcp_cors_origins`
- `nt_mcp_admin_user` — **obrigatório** (sem ele o addon nega 401, fail-closed)
- **Trusted proxies**: configure na aba **Security** do WHMCS — herdado automaticamente pelo addon. `nt_mcp_trusted_proxies` agora é **opcional/aditivo**.
- Escrita destrutiva/financeira: opt-in via `nt_mcp_enable_destructive/financial/cost/comms = 1`

## Verificação pós-deploy (operador)

- Confirmar a chave nativa: `SELECT setting, value FROM tblconfiguration WHERE setting LIKE '%roxy%';` — se não for `TrustedProxyIps`, o código degrada com segurança para o comportamento anterior (ajuste de 1 linha).
- O IP nas entradas "MCP" do Activity Log deve coincidir com o dos logins admin (objetivo da unificação).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPpxQaYVFCBhqN59pYRwuf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Higienização/redação automática de dados sensíveis em respostas (clientes, produtos e métodos de pagamento).
  * Novas camadas de proteção para TLS, CORS, rate limiting em OAuth e validação mais rigorosa de IPs/proxies.
  * Melhorias nos controles de acesso e de escrita, com reforço contra impersonação.
* **Bug Fixes**
  * OAuth/admin passam a negar quando configurações críticas não estão definidas (fail-closed).
  * CORS agora retorna erro explícito (503) quando a allowlist não pode ser lida.
  * POST com corpo acima de 1 MB agora é rejeitado (413).
* **Tests**
  * Expansão da cobertura para TLS, resolução de IP, CORS, redaction e gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->